### PR TITLE
Add composer support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,20 @@
+{
+   "name":"fgrosse/phpasn1",
+   "description":"ASN.1 Library",
+   "type":"library",
+   "homepage":"https://github.com/FGrosse/PHPASN1",
+   "authors":[{
+       "name":"Friedrich Große",
+       "homepage":"https://github.com/FGrosse",
+       "role":"Author"
+   }],
+   "require":{
+       "php": ">=5.3.0"
+   },
+   "require-dev":{
+       "phpunit/phpunit":"~4.1"
+   },
+   "autoload":{
+       "classmap": ["classes/"]
+   }
+}


### PR DESCRIPTION
Add composer support to allow easier inclusion in other libraries that depend upon this one.

For more information, see https://getcomposer.org/

Also, it would nice to reference the library on packagist.org to allow developpers to find/include it easily.