### PR TITLE
[#4] Implement long form of the identifiers

### DIFF
--- a/lib/ASN1/Base128.php
+++ b/lib/ASN1/Base128.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace FG\ASN1;
+
+/**
+ * A base-128 decoder.
+ */
+class Base128
+{
+    /**
+     * @param integer $value
+     *
+     * @return string
+     */
+    public static function encode($value)
+    {
+        $octets = chr($value & 0x7F);
+        $value >>= 7;
+
+        while ($value > 0) {
+            $octets .= chr(0x80 | ($value & 0x7F));
+            $value >>= 7;
+        }
+
+        return strrev($octets);
+    }
+
+    /**
+     * @param string $octets
+     *
+     * @return integer
+     */
+    public static function decode($octets)
+    {
+        $bitsMax = (PHP_INT_SIZE * 8) - 1;
+        $bitsUsed = 0;
+        $bitsPerOctet = 7;
+        $value = 0;
+        $i = 0;
+
+        while (true) {
+            if (!isset($octets[$i])) {
+                throw new \InvalidArgumentException(sprintf('Malformed base-128 encoded value (0x%s).', strtoupper(bin2hex($octets)) ?: '0'));
+            }
+
+            $bitsUsed += $bitsPerOctet;
+            if ($bitsUsed > $bitsMax) {
+                throw new \InvalidArgumentException(sprintf('Value (0x%s) exceeds the maximum integer length when base128-decoded.', strtoupper(bin2hex($octets))));
+            }
+
+            $octet = ord($octets[$i++]);
+            $value = ($value << $bitsPerOctet) + ($octet & 0x7F);
+
+            if (0 === ($octet & 0x80)) {
+                break;
+            }
+        }
+
+        return $value;
+    }
+}

--- a/lib/ASN1/ExplicitlyTaggedObject.php
+++ b/lib/ASN1/ExplicitlyTaggedObject.php
@@ -67,7 +67,14 @@ class ExplicitlyTaggedObject extends Object
 
     public function getType()
     {
-        return Identifier::create(Identifier::CLASS_CONTEXT_SPECIFIC, true, $this->tag);
+        return ord($this->getIdentifier());
+    }
+
+    public function getIdentifier()
+    {
+        $identifier = Identifier::create(Identifier::CLASS_CONTEXT_SPECIFIC, true, $this->tag);
+
+        return is_int($identifier) ? chr($identifier) : $identifier;
     }
 
     public function getTag()
@@ -77,10 +84,11 @@ class ExplicitlyTaggedObject extends Object
 
     public static function fromBinary(&$binaryData, &$offsetIndex = 0)
     {
-        $identifierOctet = ord($binaryData[$offsetIndex++]);
+        $identifier = self::parseBinaryIdentifier($binaryData, $offsetIndex);
+        $identifierOctet = ord($identifier);
         assert(Identifier::isContextSpecificClass($identifierOctet));
         assert(Identifier::isConstructed($identifierOctet));
-        $tag = Identifier::getTagNumber($identifierOctet);
+        $tag = Identifier::getTagNumber($identifier);
 
         $contentLength = self::parseContentLength($binaryData, $offsetIndex);
         $offsetIndexOfDecoratedObject = $offsetIndex;

--- a/lib/ASN1/Object.php
+++ b/lib/ASN1/Object.php
@@ -96,7 +96,7 @@ abstract class Object implements Parsable
      */
     public function getBinary()
     {
-        $result  = chr($this->getType());
+        $result  = $this->getIdentifier();
         $result .= $this->createLengthPart();
         $result .= $this->getEncodedValue();
 

--- a/lib/ASN1/Object.php
+++ b/lib/ASN1/Object.php
@@ -72,6 +72,25 @@ abstract class Object implements Parsable
     abstract public function getType();
 
     /**
+     * Returns all identifier octets. If an inheriting class models a tag with
+     * the long form identifier format, it MUST reimplement this method to
+     * return all octets of the identifier.
+     *
+     * @return string Identifier as a set of octets
+     * @throws \LogicException If the identifier format is long form
+     */
+    public function getIdentifier()
+    {
+        $firstOctet = $this->getType();
+
+        if (Identifier::LONG_FORM === (Identifier::LONG_FORM & $firstOctet)) {
+            throw new \LogicException(sprintf('Identifier of %s uses the long form and must therefor override "Object::getIdentifier()".', get_class($this)));
+        }
+
+        return chr($firstOctet);
+    }
+
+    /**
      * Encode this object using DER encoding
      * @return string the full binary representation of the complete object
      */

--- a/lib/ASN1/Object.php
+++ b/lib/ASN1/Object.php
@@ -252,18 +252,7 @@ abstract class Object implements Parsable
                     return new UnknownConstructedObject($binaryData, $offsetIndex);
                 } else {
 
-                    $identifier = $binaryData[$offsetIndex++];
-
-                    if (Identifier::LONG_FORM === (Identifier::LONG_FORM & $identifierOctet)) {
-                        while (true) {
-                            $identifier .= $octet = $binaryData[$offsetIndex++];
-
-                            if (0 === (ord($octet) & 0x80)) {
-                                break;
-                            }
-                        }
-                    }
-
+                    $identifier = self::parseBinaryIdentifier($binaryData, $offsetIndex);
                     $lengthOfUnknownObject = self::parseContentLength($binaryData, $offsetIndex);
                     $offsetIndex += $lengthOfUnknownObject;
 
@@ -282,6 +271,25 @@ abstract class Object implements Parsable
             $message = 'Can not create an '.Identifier::getName($expectedIdentifier).' from an '.Identifier::getName($identifierOctet);
             throw new ParserException($message, $offsetForExceptionHandling);
         }
+    }
+
+    protected static function parseBinaryIdentifier($binaryData, &$offsetIndex)
+    {
+        $identifier = $binaryData[$offsetIndex++];
+
+        if (Identifier::LONG_FORM !== (Identifier::LONG_FORM & ord($identifier))) {
+            return $identifier;
+        }
+
+        while (true) {
+            $identifier .= $octet = $binaryData[$offsetIndex++];
+
+            if (0 === (ord($octet) & 0x80)) {
+                break;
+            }
+        }
+
+        return $identifier;
     }
 
     protected static function parseContentLength(&$binaryData, &$offsetIndex, $minimumLength = 0)

--- a/lib/ASN1/Object.php
+++ b/lib/ASN1/Object.php
@@ -160,7 +160,7 @@ abstract class Object implements Parsable
      */
     public function getObjectLength()
     {
-        $nrOfIdentifierOctets = 1; // does not support identifier long form yet
+        $nrOfIdentifierOctets = strlen($this->getIdentifier());
         $contentLength = $this->getContentLength();
         $nrOfLengthOctets = $this->getNumberOfLengthOctets($contentLength);
 

--- a/lib/ASN1/Universal/RelativeObjectIdentifier.php
+++ b/lib/ASN1/Universal/RelativeObjectIdentifier.php
@@ -10,6 +10,7 @@
 
 namespace FG\ASN1\Universal;
 
+use FG\ASN1\Base128;
 use FG\ASN1\Parsable;
 use FG\ASN1\Identifier;
 use FG\ASN1\Exception\GeneralException;
@@ -46,16 +47,19 @@ class RelativeObjectIdentifier extends ObjectIdentifier implements Parsable
         $oidString = '';
         $octetsToRead = $contentLength;
         while ($octetsToRead > 0) {
-            $number = 0;
+            $octets = '';
+
             do {
-                if ($octetsToRead == 0) {
+                if (0 === $octetsToRead) {
                     throw new ParserException('Malformed ASN.1 Relative Object Identifier', $offsetIndex-1);
                 }
-                $octet = ord($binaryData[$offsetIndex++]);
-                $number = ($number << 7) + ($octet & 0x7F);
+
                 $octetsToRead--;
-            } while ($octet & 0x80);
-            $oidString .= "{$number}.";
+                $octet = $binaryData[$offsetIndex++];
+                $octets .= $octet;
+            } while (ord($octet) & 0x80);
+
+            $oidString .= sprintf('%d.', Base128::decode($octets));
         }
 
         // remove trailing '.'

--- a/lib/ASN1/UnknownConstructedObject.php
+++ b/lib/ASN1/UnknownConstructedObject.php
@@ -12,7 +12,7 @@ namespace FG\ASN1;
 
 class UnknownConstructedObject extends Construct
 {
-    private $identifierOctet;
+    private $identifier;
     private $contentLength;
 
     /**
@@ -22,8 +22,9 @@ class UnknownConstructedObject extends Construct
      */
     public function __construct($binaryData, &$offsetIndex)
     {
-        $this->identifierOctet = $binaryData[$offsetIndex++];
+        $this->identifier = self::parseBinaryIdentifier($binaryData, $offsetIndex);
         $this->contentLength = self::parseContentLength($binaryData, $offsetIndex);
+
 
         $children = array();
         $octetsToRead = $this->contentLength;
@@ -39,7 +40,12 @@ class UnknownConstructedObject extends Construct
 
     public function getType()
     {
-        return $this->identifierOctet;
+        return ord($this->identifier);
+    }
+
+    public function getIdentifier()
+    {
+        return $this->identifier;
     }
 
     protected function calculateContentLength()

--- a/lib/ASN1/UnknownObject.php
+++ b/lib/ASN1/UnknownObject.php
@@ -15,11 +15,19 @@ class UnknownObject extends Object
     /** @var string */
     private $value;
 
-    private $identifierOctet;
+    private $identifier;
 
-    public function __construct($identifierOctet, $contentLength)
+    /**
+     * @param string|integer $identifier Either the first identifier octet as int or all identifier bytes as a string
+     * @param integer        $contentLength
+     */
+    public function __construct($identifier, $contentLength)
     {
-        $this->identifierOctet = $identifierOctet;
+        if (is_int($identifier)) {
+            $identifier = chr($identifier);
+        }
+
+        $this->identifier = $identifier;
         $this->value = "Unparsable Object ({$contentLength} bytes)";
         $this->setContentLength($contentLength);
     }
@@ -31,7 +39,12 @@ class UnknownObject extends Object
 
     public function getType()
     {
-        return $this->identifierOctet;
+        return ord($this->identifier[0]);
+    }
+
+    public function getIdentifier()
+    {
+        return $this->identifier;
     }
 
     protected function calculateContentLength()

--- a/tests/ASN1/Base128Test.php
+++ b/tests/ASN1/Base128Test.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace FG\Tests\ASN1;
+
+use FG\ASN1\Base128;
+
+class Base128Test extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider getDataToDecode
+     */
+    public function testEncode($value, $expected)
+    {
+        $this->assertEquals($expected, Base128::encode($value));
+    }
+
+    /**
+     * @dataProvider getDataToDecode
+     */
+    public function testDecode($expected, $octets)
+    {
+        $this->assertEquals($expected, Base128::decode($octets));
+    }
+
+    public function getDataToDecode()
+    {
+        return array(
+            array(0x00000000, "\x00"),
+            array(0x0000007F, "\x7F"),
+            array(0x00000080, "\x81\x00"),
+            array(0x00002000, "\xC0\x00"),
+            array(0x001FFFFF, "\xFF\xFF\x7F"),
+            array(0x0FFFFFFF, "\xFF\xFF\xFF\x7F"),
+        );
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Malformed base-128 encoded value (0xFFFF).
+     */
+    public function testDecodeFailsIfLastOctetSignificantBitSet()
+    {
+        Base128::decode("\xFF\xFF");
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Value (0xFFFFFFFFFFFFFFFFFFFF7F) exceeds the maximum integer length when base128-decoded.
+     */
+    public function testDecodeFailsIfOverflows()
+    {
+        Base128::decode("\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x7F");
+    }
+}

--- a/tests/ASN1/Composite/RelativeDistinguishedNameTest.php
+++ b/tests/ASN1/Composite/RelativeDistinguishedNameTest.php
@@ -25,6 +25,12 @@ class RelativeDistinguishedNameTest extends ASN1TestCase
        $this->assertEquals(Identifier::SET, $object->getType());
    }
 
+   public function testGetIdentifier()
+   {
+       $object = new RelativeDistinguishedName(OID::COMMON_NAME, new UTF8String("Friedrich Große"));
+       $this->assertEquals(chr(Identifier::SET), $object->getIdentifier());
+   }
+
     public function testContent()
     {
         $oid = OID::COMMON_NAME;

--- a/tests/ASN1/ExplicitlyTaggedConstructTest.php
+++ b/tests/ASN1/ExplicitlyTaggedConstructTest.php
@@ -24,6 +24,13 @@ class ExplicitlyTaggedObjectTest extends ASN1TestCase
         $this->assertEquals($expectedType, $asn->getType());
     }
 
+    public function testGetIdentifier()
+    {
+        $asn = new ExplicitlyTaggedObject(0x1E, new PrintableString('test'));
+        $expectedIdentifier = chr(Identifier::create(Identifier::CLASS_CONTEXT_SPECIFIC, $isConstructed = true, 0x1E));
+        $this->assertEquals($expectedIdentifier, $asn->getIdentifier());
+    }
+
     public function testGetTag()
     {
         $object = new ExplicitlyTaggedObject(0, new PrintableString('test'));

--- a/tests/ASN1/ExplicitlyTaggedConstructTest.php
+++ b/tests/ASN1/ExplicitlyTaggedConstructTest.php
@@ -68,16 +68,24 @@ class ExplicitlyTaggedObjectTest extends ASN1TestCase
 
     /**
      * @depends testGetBinary
+     * @dataProvider getTags
      */
-    public function testFromBinary()
+    public function testFromBinary($originalTag)
     {
-        $originalTag = 0x02;
         $originalStringObject = new PrintableString('test');
         $originalObject = new ExplicitlyTaggedObject($originalTag, $originalStringObject);
         $binaryData = $originalObject->getBinary();
 
         $parsedObject = ExplicitlyTaggedObject::fromBinary($binaryData);
         $this->assertEquals($originalObject, $parsedObject);
+    }
+
+    public function getTags()
+    {
+        return array(
+            array(0x02),
+            array(0xDEADBEEF),
+        );
     }
 }
 

--- a/tests/ASN1/IdentifierTest.php
+++ b/tests/ASN1/IdentifierTest.php
@@ -72,36 +72,15 @@ class IdentifierTest extends ASN1TestCase
         $this->assertEquals(1, Identifier::getTagNumber((Identifier::CLASS_CONTEXT_SPECIFIC << 6) | 0x01));
         $this->assertEquals(3, Identifier::getTagNumber((Identifier::CLASS_CONTEXT_SPECIFIC << 6) | 0x03));
         $this->assertEquals(0xFF, Identifier::getTagNumber("\x1F\x81\x7F"));
-        $this->assertEquals(0xFF, Identifier::getTagNumber("\x1F\x81\x7F"));
-    }
-
-    /**
-     * Should fail on both 64-bit and 32-bit versions of PHP.
-     *
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Identifier (0xFFFFFFFFFFFFFFFFFFFF7F) is too long and thus unsupported
-     */
-    public function testGetTagNumberFailsIfIdentifierTooLong()
-    {
-        Identifier::getTagNumber("\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x7F");
     }
 
     /**
      * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Malformed identifier (0x1F)
+     * @expectedExceptionMessage Malformed base-128 encoded value (0x0).
      */
     public function testGetTagNumberFailsIfLongFormIdentifierMissingSubsequentOctets()
     {
         Identifier::getTagNumber(Identifier::LONG_FORM);
-    }
-
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Malformed identifier (0xFFFF)
-     */
-    public function testGetTagNumberFailsIfLastOctetSignificantBitSet()
-    {
-        Identifier::getTagNumber("\xFF\xFF");
     }
 
     public function testIsSpecificClass()

--- a/tests/ASN1/IdentifierTest.php
+++ b/tests/ASN1/IdentifierTest.php
@@ -20,6 +20,8 @@ class IdentifierTest extends ASN1TestCase
         $this->assertEquals(0x02, Identifier::create(Identifier::CLASS_UNIVERSAL, $isConstructed = false, 0x02));
         $this->assertEquals(0x30, Identifier::create(Identifier::CLASS_UNIVERSAL, $isConstructed = true,  0x10));
         $this->assertEquals(0xB3, Identifier::create(Identifier::CLASS_CONTEXT_SPECIFIC, $isConstructed = true,  0x13));
+        $this->assertEquals("\x1F\x1F", Identifier::create(Identifier::CLASS_UNIVERSAL, $isConstructed = false, 0x1F));
+        $this->assertEquals("\x1F\x81\x7F", Identifier::create(Identifier::CLASS_UNIVERSAL, $isConstructed = false, 0xFF));
     }
 
     public function testGetIdentifierName()

--- a/tests/ASN1/ObjectTest.php
+++ b/tests/ASN1/ObjectTest.php
@@ -13,6 +13,7 @@ namespace FG\Test\ASN1;
 use FG\ASN1\ExplicitlyTaggedObject;
 use FG\Test\ASN1TestCase;
 use FG\ASN1\Object;
+use FG\ASN1\UnknownConstructedObject;
 use FG\ASN1\UnknownObject;
 use FG\ASN1\Identifier;
 use FG\ASN1\Universal\BitString;
@@ -185,6 +186,16 @@ class ObjectTest extends ASN1TestCase
         $binaryData = $taggedObject->getBinary();
         $parsedObject = Object::fromBinary($binaryData);
         $this->assertTrue($parsedObject instanceof ExplicitlyTaggedObject);
+
+        // An unkown constructed object containing 2 integer children, first
+        // 3 bytes are the identifier.
+        $binaryData = "\x3F\x81\x7F\x06".chr(Identifier::INTEGER)."\x01\x42".chr(Identifier::INTEGER)."\x01\x69";
+        $offsetIndex = 0;
+        $parsedObject = OBject::fromBinary($binaryData, $offsetIndex);
+        $this->assertTrue($parsedObject instanceof UnknownConstructedObject);
+        $this->assertEquals(substr($binaryData, 0, 3), $parsedObject->getIdentifier());
+        $this->assertCount(2, $parsedObject->getContent());
+        $this->assertEquals(strlen($binaryData), $offsetIndex);
 
         // First 3 bytes are the identifier
         $binaryData = "\x1F\x81\x7F\x01\xFF";

--- a/tests/ASN1/ObjectTest.php
+++ b/tests/ASN1/ObjectTest.php
@@ -13,6 +13,7 @@ namespace FG\Test\ASN1;
 use FG\ASN1\ExplicitlyTaggedObject;
 use FG\Test\ASN1TestCase;
 use FG\ASN1\Object;
+use FG\ASN1\UnknownObject;
 use FG\ASN1\Identifier;
 use FG\ASN1\Universal\BitString;
 use FG\ASN1\Universal\Boolean;
@@ -184,6 +185,15 @@ class ObjectTest extends ASN1TestCase
         $binaryData = $taggedObject->getBinary();
         $parsedObject = Object::fromBinary($binaryData);
         $this->assertTrue($parsedObject instanceof ExplicitlyTaggedObject);
+
+        // First 3 bytes are the identifier
+        $binaryData = "\x1F\x81\x7F\x01\xFF";
+        $offsetIndex = 0;
+        $parsedObject = Object::fromBinary($binaryData, $offsetIndex);
+        $this->assertTrue($parsedObject instanceof UnknownObject);
+        $this->assertEquals(substr($binaryData, 0, 3), $parsedObject->getIdentifier());
+        $this->assertEquals('Unparsable Object (1 bytes)', $parsedObject->getContent());
+        $this->assertEquals(strlen($binaryData), $offsetIndex);
     }
 
     /**

--- a/tests/ASN1/ObjectTest.php
+++ b/tests/ASN1/ObjectTest.php
@@ -196,6 +196,7 @@ class ObjectTest extends ASN1TestCase
         $this->assertEquals(substr($binaryData, 0, 3), $parsedObject->getIdentifier());
         $this->assertCount(2, $parsedObject->getContent());
         $this->assertEquals(strlen($binaryData), $offsetIndex);
+        $this->assertEquals(10, $parsedObject->getObjectLength());
 
         // First 3 bytes are the identifier
         $binaryData = "\x1F\x81\x7F\x01\xFF";
@@ -205,6 +206,7 @@ class ObjectTest extends ASN1TestCase
         $this->assertEquals(substr($binaryData, 0, 3), $parsedObject->getIdentifier());
         $this->assertEquals('Unparsable Object (1 bytes)', $parsedObject->getContent());
         $this->assertEquals(strlen($binaryData), $offsetIndex);
+        $this->assertEquals(5, $parsedObject->getObjectLength());
     }
 
     /**

--- a/tests/ASN1/Universal/BMPStringTest.php
+++ b/tests/ASN1/Universal/BMPStringTest.php
@@ -23,6 +23,12 @@ class BMPStringTest extends ASN1TestCase
         $this->assertEquals(Identifier::BMP_STRING, $object->getType());
     }
 
+    public function testGetIdentifier()
+    {
+        $object = new BMPString("Hello World");
+        $this->assertEquals(chr(Identifier::BMP_STRING), $object->getIdentifier());
+    }
+
     public function testContent()
     {
         $object = new BMPString("Hello World");

--- a/tests/ASN1/Universal/BitStringTest.php
+++ b/tests/ASN1/Universal/BitStringTest.php
@@ -23,6 +23,12 @@ class BitStringTest extends ASN1TestCase
         $this->assertEquals(Identifier::BITSTRING, $object->getType());
     }
 
+    public function testGetIdentifier()
+    {
+        $object = new BitString('A0 12 00 43');
+        $this->assertEquals(chr(Identifier::BITSTRING), $object->getIdentifier());
+    }
+
     public function testContent()
     {
         $object = new BitString('A01200C3');

--- a/tests/ASN1/Universal/BooleanTest.php
+++ b/tests/ASN1/Universal/BooleanTest.php
@@ -23,6 +23,12 @@ class BooleanTest extends ASN1TestCase
         $this->assertEquals(Identifier::BOOLEAN, $object->getType());
     }
 
+    public function testGetIdentifier()
+    {
+        $object = new Boolean(true);
+        $this->assertEquals(chr(Identifier::BOOLEAN), $object->getIdentifier());
+    }
+
     public function testContent()
     {
         $object = new Boolean(true);

--- a/tests/ASN1/Universal/CharacterStringTest.php
+++ b/tests/ASN1/Universal/CharacterStringTest.php
@@ -23,6 +23,12 @@ class CharacterStringTest extends ASN1TestCase
         $this->assertEquals(Identifier::CHARACTER_STRING, $object->getType());
     }
 
+    public function testGetIdentifier()
+    {
+        $object = new CharacterString("Hello World");
+        $this->assertEquals(chr(Identifier::CHARACTER_STRING), $object->getIdentifier());
+    }
+
     public function testContent()
     {
         $object = new CharacterString("Hello World");

--- a/tests/ASN1/Universal/EnumeratedTest.php
+++ b/tests/ASN1/Universal/EnumeratedTest.php
@@ -23,6 +23,12 @@ class EnumeratedTest extends ASN1TestCase
         $this->assertEquals(Identifier::ENUMERATED, $object->getType());
     }
 
+    public function testGetIdentifier()
+    {
+        $object = new Enumerated(1);
+        $this->assertEquals(chr(Identifier::ENUMERATED), $object->getIdentifier());
+    }
+
     public function testContent()
     {
         $object = new Enumerated(0);

--- a/tests/ASN1/Universal/GeneralStringTest.php
+++ b/tests/ASN1/Universal/GeneralStringTest.php
@@ -23,6 +23,12 @@ class GeneralStringTest extends ASN1TestCase
         $this->assertEquals(Identifier::GENERAL_STRING, $object->getType());
     }
 
+    public function testGetIdentifier()
+    {
+        $object = new GeneralString("Hello World");
+        $this->assertEquals(chr(Identifier::GENERAL_STRING), $object->getIdentifier());
+    }
+
     public function testContent()
     {
         $object = new GeneralString("Hello World");

--- a/tests/ASN1/Universal/GeneralizedTimeTest.php
+++ b/tests/ASN1/Universal/GeneralizedTimeTest.php
@@ -30,6 +30,12 @@ class GeneralizedTimeTest extends ASN1TestCase
         $this->assertEquals(Identifier::GENERALIZED_TIME, $object->getType());
     }
 
+    public function testGetIdentifier()
+    {
+        $object = new GeneralizedTime();
+        $this->assertEquals(chr(Identifier::GENERALIZED_TIME), $object->getIdentifier());
+    }
+
     public function testGetContent()
     {
         $now = new \DateTime();

--- a/tests/ASN1/Universal/GraphicStringTest.php
+++ b/tests/ASN1/Universal/GraphicStringTest.php
@@ -23,6 +23,12 @@ class GraphicStringTest extends ASN1TestCase
         $this->assertEquals(Identifier::GRAPHIC_STRING, $object->getType());
     }
 
+    public function testGetIdentifier()
+    {
+        $object = new GraphicString("Hello World");
+        $this->assertEquals(chr(Identifier::GRAPHIC_STRING), $object->getIdentifier());
+    }
+
     public function testContent()
     {
         $object = new GraphicString("Hello World");

--- a/tests/ASN1/Universal/IA5StringTest.php
+++ b/tests/ASN1/Universal/IA5StringTest.php
@@ -23,6 +23,12 @@ class IA5StringTest extends ASN1TestCase
         $this->assertEquals(Identifier::IA5_STRING, $object->getType());
     }
 
+    public function testGetIdentifier()
+    {
+        $object = new IA5String("Hello World");
+        $this->assertEquals(chr(Identifier::IA5_STRING), $object->getIdentifier());
+    }
+
     public function testContent()
     {
         $object = new IA5String("Hello World");

--- a/tests/ASN1/Universal/IntegerTest.php
+++ b/tests/ASN1/Universal/IntegerTest.php
@@ -23,6 +23,12 @@ class IntegerTest extends ASN1TestCase
         $this->assertEquals(Identifier::INTEGER, $object->getType());
     }
 
+    public function testGetIdentifier()
+    {
+        $object = new Integer(123);
+        $this->assertEquals(chr(Identifier::INTEGER), $object->getIdentifier());
+    }
+
     public function testContent()
     {
         $object = new Integer(1234);

--- a/tests/ASN1/Universal/NullTest.php
+++ b/tests/ASN1/Universal/NullTest.php
@@ -23,6 +23,12 @@ class NullTest extends ASN1TestCase
         $this->assertEquals(Identifier::NULL, $object->getType());
     }
 
+    public function testGetIdentifier()
+    {
+        $object = new Null();
+        $this->assertEquals(chr(Identifier::NULL), $object->getIdentifier());
+    }
+
     public function testContent()
     {
         $object = new Null();

--- a/tests/ASN1/Universal/NumericStringTest.php
+++ b/tests/ASN1/Universal/NumericStringTest.php
@@ -23,6 +23,12 @@ class NumericStringTest extends ASN1TestCase
         $this->assertEquals(Identifier::NUMERIC_STRING, $object->getType());
     }
 
+    public function testGetIdentifier()
+    {
+        $object = new NumericString("1234");
+        $this->assertEquals(chr(Identifier::NUMERIC_STRING), $object->getIdentifier());
+    }
+
     public function testContent()
     {
         $object = new NumericString("123 45 67890");

--- a/tests/ASN1/Universal/ObjectDescriptorTest.php
+++ b/tests/ASN1/Universal/ObjectDescriptorTest.php
@@ -23,6 +23,12 @@ class ObjectDescriptorTest extends ASN1TestCase
         $this->assertEquals(Identifier::OBJECT_DESCRIPTOR, $object->getType());
     }
 
+    public function testGetIdentifier()
+    {
+        $object = new ObjectDescriptor("NumericString character abstract syntax");
+        $this->assertEquals(chr(Identifier::OBJECT_DESCRIPTOR), $object->getIdentifier());
+    }
+
     public function testContent()
     {
         $object = new ObjectDescriptor("PrintableString character abstract syntax");

--- a/tests/ASN1/Universal/ObjectIdentifierTest.php
+++ b/tests/ASN1/Universal/ObjectIdentifierTest.php
@@ -32,6 +32,12 @@ class ObjectIdentifierTest extends ASN1TestCase
         $this->assertEquals(Identifier::OBJECT_IDENTIFIER, $object->getType());
     }
 
+    public function testGetIdentifier()
+    {
+        $object = new ObjectIdentifier('1.2.3');
+        $this->assertEquals(chr(Identifier::OBJECT_IDENTIFIER), $object->getIdentifier());
+    }
+
     public function testContent()
     {
         $object = new ObjectIdentifier('1.2.3');

--- a/tests/ASN1/Universal/OctetStringTest.php
+++ b/tests/ASN1/Universal/OctetStringTest.php
@@ -23,6 +23,12 @@ class OctetStringTest extends ASN1TestCase
         $this->assertEquals(Identifier::OCTETSTRING, $object->getType());
     }
 
+    public function testGetIdentifier()
+    {
+        $object = new OctetString('30 14 06 08 2B 06 01 05 05 07 03 01 06 08 2B 06 01 05 05 07 03 02');
+        $this->assertEquals(chr(Identifier::OCTETSTRING), $object->getIdentifier());
+    }
+
     public function testContent()
     {
         $object = new OctetString('A01200C3');

--- a/tests/ASN1/Universal/PrintableStringTest.php
+++ b/tests/ASN1/Universal/PrintableStringTest.php
@@ -23,6 +23,12 @@ class PrintableStringTest extends ASN1TestCase
         $this->assertEquals(Identifier::PRINTABLE_STRING, $object->getType());
     }
 
+    public function testGetIdentifier()
+    {
+        $object = new PrintableString("Hello World");
+        $this->assertEquals(chr(Identifier::PRINTABLE_STRING), $object->getIdentifier());
+    }
+
     public function testContent()
     {
         $object = new PrintableString("Hello World");

--- a/tests/ASN1/Universal/RelativeObjectIdentifierTest.php
+++ b/tests/ASN1/Universal/RelativeObjectIdentifierTest.php
@@ -23,6 +23,12 @@ class RelativeObjectIdentifierTest extends ASN1TestCase
         $this->assertEquals(Identifier::RELATIVE_OID, $object->getType());
     }
 
+    public function testGetIdentifier()
+    {
+        $object = new RelativeObjectIdentifier('8751.3.2');
+        $this->assertEquals(chr(Identifier::RELATIVE_OID), $object->getIdentifier());
+    }
+
     public function testContent()
     {
         $object = new RelativeObjectIdentifier('8751.3.2');

--- a/tests/ASN1/Universal/SequenceTest.php
+++ b/tests/ASN1/Universal/SequenceTest.php
@@ -26,6 +26,12 @@ class SequenceTest extends ASN1TestCase
         $this->assertEquals(Identifier::SEQUENCE, $object->getType());
     }
 
+    public function testGetIdentifier()
+    {
+        $object = new Sequence();
+        $this->assertEquals(chr(Identifier::SEQUENCE), $object->getIdentifier());
+    }
+
     public function testContent()
     {
         $child1 = new Integer(123);

--- a/tests/ASN1/Universal/SetTest.php
+++ b/tests/ASN1/Universal/SetTest.php
@@ -26,6 +26,12 @@ class SetTest extends ASN1TestCase
         $this->assertEquals(Identifier::SET, $object->getType());
     }
 
+    public function testGetIdentifier()
+    {
+        $object = new Set();
+        $this->assertEquals(chr(Identifier::SET), $object->getIdentifier());
+    }
+
     public function testContent()
     {
         $child1 = new Integer(123);

--- a/tests/ASN1/Universal/T61StringTest.php
+++ b/tests/ASN1/Universal/T61StringTest.php
@@ -23,6 +23,12 @@ class T61StringTest extends ASN1TestCase
         $this->assertEquals(Identifier::T61_STRING, $object->getType());
     }
 
+    public function testGetIdentifier()
+    {
+        $object = new T61String("Hello World");
+        $this->assertEquals(chr(Identifier::T61_STRING), $object->getIdentifier());
+    }
+
     public function testContent()
     {
         $object = new T61String("Hello World");

--- a/tests/ASN1/Universal/UTCTimeTest.php
+++ b/tests/ASN1/Universal/UTCTimeTest.php
@@ -30,6 +30,12 @@ class UTCTimeTest extends ASN1TestCase
         $this->assertEquals(Identifier::UTC_TIME, $object->getType());
     }
 
+    public function testGetIdentifier()
+    {
+        $object = new UTCTime();
+        $this->assertEquals(chr(Identifier::UTC_TIME), $object->getIdentifier());
+    }
+
     public function testGetContent()
     {
         $now = new \DateTime();

--- a/tests/ASN1/Universal/UTF8StringTest.php
+++ b/tests/ASN1/Universal/UTF8StringTest.php
@@ -23,6 +23,12 @@ class UTF8StringTest extends ASN1TestCase
         $this->assertEquals(Identifier::UTF8_STRING, $object->getType());
     }
 
+    public function testGetIdentifier()
+    {
+        $object = new UTF8String("Hello World");
+        $this->assertEquals(chr(Identifier::UTF8_STRING), $object->getIdentifier());
+    }
+
     public function testContent()
     {
         $object = new UTF8String("Hello World");

--- a/tests/ASN1/Universal/UniversalStringTest.php
+++ b/tests/ASN1/Universal/UniversalStringTest.php
@@ -23,6 +23,12 @@ class UniversalStringTest extends ASN1TestCase
         $this->assertEquals(Identifier::UNIVERSAL_STRING, $object->getType());
     }
 
+    public function testGetIdentifier()
+    {
+        $object = new UniversalString("Hello World");
+        $this->assertEquals(chr(Identifier::UNIVERSAL_STRING), $object->getIdentifier());
+    }
+
     public function testContent()
     {
         $object = new UniversalString("Hello World");

--- a/tests/ASN1/Universal/VisibleStringTest.php
+++ b/tests/ASN1/Universal/VisibleStringTest.php
@@ -23,6 +23,12 @@ class VisibleStringTest extends ASN1TestCase
         $this->assertEquals(Identifier::VISIBLE_STRING, $object->getType());
     }
 
+    public function testGetIdentifier()
+    {
+        $object = new VisibleString("Hello World");
+        $this->assertEquals(chr(Identifier::VISIBLE_STRING), $object->getIdentifier());
+    }
+
     public function testContent()
     {
         $object = new VisibleString("Hello World");

--- a/tests/X509/CSR/AttributesTest.php
+++ b/tests/X509/CSR/AttributesTest.php
@@ -28,6 +28,12 @@ class AttributesTest extends ASN1TestCase
         $this->assertEquals(0xa0, $object->getType());  // Identifier indicates this object is context specific and constructed
     }
 
+    public function testGetIdentifier()
+    {
+        $object = new Attributes();
+        $this->assertEquals(chr(0xa0), $object->getIdentifier());
+    }
+
     public function testGetContent()
     {
         $attributes = new Attributes();

--- a/tests/X509/CertificateExtensionTest.php
+++ b/tests/X509/CertificateExtensionTest.php
@@ -28,6 +28,12 @@ class CertificateExtensionTest extends ASN1TestCase
         $this->assertEquals(Identifier::SET, $object->getType());
     }
 
+    public function testGetIdentifier()
+    {
+        $object = new CertificateExtensions();
+        $this->assertEquals(chr(Identifier::SET), $object->getIdentifier());
+    }
+
     public function testGetContent()
     {
         $object = new CertificateExtensions();

--- a/tests/X509/CertificateSubjectTest.php
+++ b/tests/X509/CertificateSubjectTest.php
@@ -22,6 +22,12 @@ class CertificateSubjectTest extends ASN1TestCase
         $object = new CertificateSubject("Friedrich Große", "friedrich.grosse@foo.de", "Organization", "Locality", "State", "Country", "OrgaUnit");
         $this->assertEquals(Identifier::SEQUENCE, $object->getType());
     }
+
+    public function testGetIdentifier()
+    {
+        $object = new CertificateSubject("Friedrich Große", "friedrich.grosse@foo.de", "Organization", "Locality", "State", "Country", "OrgaUnit");
+        $this->assertEquals(chr(Identifier::SEQUENCE), $object->getIdentifier());
+    }
     /*
     public function testFromBinary() {
         $originalobject = new CertificateSubject("Friedrich Große", "friedrich.grosse@foo.de", "Organization", "Locality", "State", "Country", "OrgaUnit");

--- a/tests/X509/DNSNameTest.php
+++ b/tests/X509/DNSNameTest.php
@@ -22,6 +22,12 @@ class DNSNameTest extends ASN1TestCase
         $this->assertEquals(0x82, $object->getType());
     }
 
+    public function testGetIdentifier()
+    {
+        $object = new DNSName("test.corvespace.de");
+        $this->assertEquals(chr(0x82), $object->getIdentifier());
+    }
+
     public function testGetContent()
     {
         $object = new DNSName("test.corvespace.de");

--- a/tests/X509/IPAddressTest.php
+++ b/tests/X509/IPAddressTest.php
@@ -22,6 +22,12 @@ class IPAddressTest extends ASN1TestCase
         $this->assertEquals(0x87, $object->getType());
     }
 
+    public function testGetIdentifier()
+    {
+        $object = new IPAddress("192.168.0.1");
+        $this->assertEquals(chr(0x87), $object->getIdentifier());
+    }
+
     public function testGetContent()
     {
         $object = new IPAddress("192.168.0.1");

--- a/tests/X509/SubjectAlternativeNamesTest.php
+++ b/tests/X509/SubjectAlternativeNamesTest.php
@@ -25,6 +25,12 @@ class SubjectAlternativeNamesTest extends ASN1TestCase
         $this->assertEquals(Identifier::OCTETSTRING, $object->getType());
     }
 
+    public function testGetIdentifier()
+    {
+        $object = new SubjectAlternativeNames();
+        $this->assertEquals(chr(Identifier::OCTETSTRING), $object->getIdentifier());
+    }
+
     public function testGetContent()
     {
         $object = new SubjectAlternativeNames();


### PR DESCRIPTION
Alright, this PR adds support for long form of the identifiers.

* should be fully backwards compatible - all methods previously working with the first identifier octet also support passing a string of identifier octets;
* biggest supported identifier depends on PHP's integer size (either 32-bit or 64-bit). That's because I'm decoding long format identifiers to integers. Don't think this won't be a problem though as longer identifiers are probably very infrequent;
* consequently fixes a silent overflow in [ObjectIdentifier](https://github.com/FGrosse/PHPASN1/blob/1966cc2/lib/ASN1/Universal/ObjectIdentifier.php#L108) - an exception *should* be thrown instead;

If something feels off, feel free to point at it.