### PR TITLE
Adds compatibility with PHP 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,11 @@ php:
   - 5.4
   - 5.5
   - 5.6
+  - 7
   - hhvm
 
 before_script:
-    - composer --dev install
+    - composer install
 
 script:
     - vendor/bin/phpunit

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ PHPASN1 can also read [BER encoded](http://en.wikipedia.org/wiki/X.690#BER_encod
 
 PHPASN1 requires at least `PHP 5.3`.
 
-It has been successfully tested using `PHP 5.3` to `PHP 5.6` and `HHVM`
+It has been successfully tested using `PHP 5.3` to `PHP 5.6`, `PHP 7` and `HHVM`
 
 For the loading of object identifier names directly from the web the [Client URL Library (CURL)](http://php.net/manual/en/book.curl.php) is used.
 
@@ -30,12 +30,14 @@ For the loading of object identifier names directly from the web the [Client URL
 
 The preferred way to install this library is to rely on Composer:
 
-    {
-        "require": {
-            // ...
-            "fgrosse/phpasn1": "dev-master"
-        }
+```json
+{
+    "require": {
+        // ...
+        "fgrosse/phpasn1": "dev-master"
     }
+}
+```
 
 ## Usage
 
@@ -55,14 +57,14 @@ use FG\ASN1\Universal\ObjectIdentifier;
 use FG\ASN1\Universal\PrintableString;
 use FG\ASN1\Universal\Sequence;
 use FG\ASN1\Universal\Set;
-use FG\ASN1\Universal\Null;
+use FG\ASN1\Universal\NullObject;
 
 $integer = new Integer(123456);        
 $boolean = new Boolean(true);
 $enum = new Enumerated(1);
 $ia5String = new IA5String('Hello world');
 
-$asnNull = new Null();
+$asnNull = new NullObject();
 $objectIdentifier1 = new ObjectIdentifier('1.2.250.1.16.9');
 $objectIdentifier2 = new ObjectIdentifier(OID::RSA_ENCRYPTION);
 $printableString = new PrintableString('Foo bar');

--- a/lib/ASN1/Object.php
+++ b/lib/ASN1/Object.php
@@ -15,7 +15,7 @@ use FG\ASN1\Universal\BitString;
 use FG\ASN1\Universal\Boolean;
 use FG\ASN1\Universal\Enumerated;
 use FG\ASN1\Universal\Integer;
-use FG\ASN1\Universal\Null;
+use FG\ASN1\Universal\NullObject;
 use FG\ASN1\Universal\ObjectIdentifier;
 use FG\ASN1\Universal\RelativeObjectIdentifier;
 use FG\ASN1\Universal\OctetString;
@@ -190,7 +190,7 @@ abstract class Object implements Parsable
             case Identifier::INTEGER:
                 return Integer::fromBinary($binaryData, $offsetIndex);
             case Identifier::NULL:
-                return Null::fromBinary($binaryData, $offsetIndex);
+                return NullObject::fromBinary($binaryData, $offsetIndex);
             case Identifier::OBJECT_IDENTIFIER:
                 return ObjectIdentifier::fromBinary($binaryData, $offsetIndex);
             case Identifier::RELATIVE_OID:

--- a/lib/ASN1/Universal/Null.php
+++ b/lib/ASN1/Universal/Null.php
@@ -10,45 +10,9 @@
 
 namespace FG\ASN1\Universal;
 
-use FG\ASN1\Object;
-use FG\ASN1\Parsable;
-use FG\ASN1\Identifier;
-use FG\ASN1\Exception\ParserException;
 
-class Null extends Object implements Parsable
-{
-    public function getType()
-    {
-        return Identifier::NULL;
-    }
-
-    protected function calculateContentLength()
-    {
-        return 0;
-    }
-
-    protected function getEncodedValue()
-    {
-        return;
-    }
-
-    public function getContent()
-    {
-        return 'NULL';
-    }
-
-    public static function fromBinary(&$binaryData, &$offsetIndex = 0)
-    {
-        self::parseIdentifier($binaryData[$offsetIndex], Identifier::NULL, $offsetIndex++);
-        $contentLength = self::parseContentLength($binaryData, $offsetIndex);
-
-        if ($contentLength != 0) {
-            throw new ParserException("An ASN.1 Null should not have a length other than zero. Extracted length was {$contentLength}", $offsetIndex);
-        }
-
-        $parsedObject = new self();
-        $parsedObject->setContentLength(0);
-
-        return $parsedObject;
-    }
+/**
+ * @deprecated Deprecated. Use {@link NullObject} instead.
+ */
+class Null extends NullObject{
 }

--- a/lib/ASN1/Universal/NullObject.php
+++ b/lib/ASN1/Universal/NullObject.php
@@ -1,0 +1,54 @@
+<?php
+/*
+ * This file is part of the PHPASN1 library.
+ *
+ * Copyright © Friedrich Große <friedrich.grosse@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FG\ASN1\Universal;
+
+use FG\ASN1\Object;
+use FG\ASN1\Parsable;
+use FG\ASN1\Identifier;
+use FG\ASN1\Exception\ParserException;
+
+class NullObject extends Object implements Parsable
+{
+    public function getType()
+    {
+        return Identifier::NULL;
+    }
+
+    protected function calculateContentLength()
+    {
+        return 0;
+    }
+
+    protected function getEncodedValue()
+    {
+        return;
+    }
+
+    public function getContent()
+    {
+        return 'NULL';
+    }
+
+    public static function fromBinary(&$binaryData, &$offsetIndex = 0)
+    {
+        self::parseIdentifier($binaryData[$offsetIndex], Identifier::NULL, $offsetIndex++);
+        $contentLength = self::parseContentLength($binaryData, $offsetIndex);
+
+        if ($contentLength != 0) {
+            throw new ParserException("An ASN.1 Null should not have a length other than zero. Extracted length was {$contentLength}", $offsetIndex);
+        }
+
+        $parsedObject = new self();
+        $parsedObject->setContentLength(0);
+
+        return $parsedObject;
+    }
+}

--- a/lib/X509/AlgorithmIdentifier.php
+++ b/lib/X509/AlgorithmIdentifier.php
@@ -10,13 +10,13 @@
 
 namespace FG\X509;
 
-use FG\ASN1\Universal\Null;
+use FG\ASN1\Universal\NullObject;
 use FG\ASN1\Composite\AttributeTypeAndValue;
 
 class AlgorithmIdentifier extends AttributeTypeAndValue
 {
     public function __construct($objectIdentifierString)
     {
-        parent::__construct($objectIdentifierString, new Null());
+        parent::__construct($objectIdentifierString, new NullObject());
     }
 }

--- a/lib/X509/PrivateKey.php
+++ b/lib/X509/PrivateKey.php
@@ -11,7 +11,7 @@
 namespace FG\X509;
 
 use FG\ASN1\OID;
-use FG\ASN1\Universal\Null;
+use FG\ASN1\Universal\NullObject;
 use FG\ASN1\Universal\Sequence;
 use FG\ASN1\Universal\BitString;
 use FG\ASN1\Universal\ObjectIdentifier;
@@ -27,7 +27,7 @@ class PrivateKey extends Sequence
         parent::__construct(
             new Sequence(
                 new ObjectIdentifier($algorithmIdentifierString),
-                new Null()
+                new NullObject()
             ),
             new BitString($hexKey)
         );

--- a/lib/X509/PublicKey.php
+++ b/lib/X509/PublicKey.php
@@ -11,7 +11,7 @@
 namespace FG\X509;
 
 use FG\ASN1\OID;
-use FG\ASN1\Universal\Null;
+use FG\ASN1\Universal\NullObject;
 use FG\ASN1\Universal\Sequence;
 use FG\ASN1\Universal\BitString;
 use FG\ASN1\Universal\ObjectIdentifier;
@@ -27,7 +27,7 @@ class PublicKey extends Sequence
         parent::__construct(
             new Sequence(
                 new ObjectIdentifier($algorithmIdentifierString),
-                new Null()
+                new NullObject()
             ),
             new BitString($hexKey)
         );

--- a/tests/ASN1/ObjectTest.php
+++ b/tests/ASN1/ObjectTest.php
@@ -18,7 +18,7 @@ use FG\ASN1\Universal\BitString;
 use FG\ASN1\Universal\Boolean;
 use FG\ASN1\Universal\Enumerated;
 use FG\ASN1\Universal\Integer;
-use FG\ASN1\Universal\Null;
+use FG\ASN1\Universal\NullObject;
 use FG\ASN1\Universal\ObjectIdentifier;
 use FG\ASN1\Universal\OctetString;
 use FG\ASN1\Universal\Sequence;
@@ -125,13 +125,13 @@ class ObjectTest extends ASN1TestCase
         $this->assertTrue($parsedObject instanceof Integer);
         $this->assertEquals($expectedObject->getContent(), $parsedObject->getContent());
 
-        /** @var \FG\ASN1\Universal\Null $parsedObject */
+        /** @var \FG\ASN1\Universal\NullObject $parsedObject */
         $binaryData = chr(Identifier::NULL);
         $binaryData .= chr(0x00);
 
-        $expectedObject = new Null();
+        $expectedObject = new NullObject();
         $parsedObject = Object::fromBinary($binaryData);
-        $this->assertTrue($parsedObject instanceof Null);
+        $this->assertTrue($parsedObject instanceof NullObject);
         $this->assertEquals($expectedObject->getContent(), $parsedObject->getContent());
 
         /** @var ObjectIdentifier $parsedObject */

--- a/tests/ASN1/Universal/NullTest.php
+++ b/tests/ASN1/Universal/NullTest.php
@@ -12,32 +12,32 @@ namespace FG\Test\ASN1\Universal;
 
 use FG\Test\ASN1TestCase;
 use FG\ASN1\Identifier;
-use FG\ASN1\Universal\Null;
+use FG\ASN1\Universal\NullObject;
 
 class NullTest extends ASN1TestCase
 {
 
     public function testGetType()
     {
-        $object = new Null();
+        $object = new NullObject();
         $this->assertEquals(Identifier::NULL, $object->getType());
     }
 
     public function testContent()
     {
-        $object = new Null();
+        $object = new NullObject();
         $this->assertEquals('NULL', $object->getContent());
     }
 
     public function testGetObjectLength()
     {
-        $object = new Null();
+        $object = new NullObject();
         $this->assertEquals(2, $object->getObjectLength());
     }
 
     public function testGetBinary()
     {
-        $object = new Null();
+        $object = new NullObject();
         $expectedType = chr(Identifier::NULL);
         $expectedLength = chr(0x00);
         $this->assertEquals($expectedType.$expectedLength, $object->getBinary());
@@ -48,9 +48,9 @@ class NullTest extends ASN1TestCase
      */
     public function testFromBinary()
     {
-        $originalobject = new Null();
+        $originalobject = new NullObject();
         $binaryData = $originalobject->getBinary();
-        $parsedObject = Null::fromBinary($binaryData);
+        $parsedObject = NullObject::fromBinary($binaryData);
         $this->assertEquals($originalobject, $parsedObject);
     }
 
@@ -59,17 +59,17 @@ class NullTest extends ASN1TestCase
      */
     public function testFromBinaryWithOffset()
     {
-        $originalobject1 = new Null();
-        $originalobject2 = new Null();
+        $originalobject1 = new NullObject();
+        $originalobject2 = new NullObject();
 
         $binaryData  = $originalobject1->getBinary();
         $binaryData .= $originalobject2->getBinary();
 
         $offset = 0;
-        $parsedObject = Null::fromBinary($binaryData, $offset);
+        $parsedObject = NullObject::fromBinary($binaryData, $offset);
         $this->assertEquals($originalobject1, $parsedObject);
         $this->assertEquals(2, $offset);
-        $parsedObject = Null::fromBinary($binaryData, $offset);
+        $parsedObject = NullObject::fromBinary($binaryData, $offset);
         $this->assertEquals($originalobject2, $parsedObject);
         $this->assertEquals(4, $offset);
     }
@@ -83,6 +83,6 @@ class NullTest extends ASN1TestCase
     {
         $binaryData  = chr(Identifier::NULL);
         $binaryData .= chr(0x01);
-        Null::fromBinary($binaryData);
+        NullObject::fromBinary($binaryData);
     }
 }

--- a/tests/DocumentationExamplesTest.php
+++ b/tests/DocumentationExamplesTest.php
@@ -18,7 +18,7 @@ use FG\ASN1\Universal\Enumerated;
 use FG\ASN1\Universal\IA5String;
 use FG\ASN1\Universal\Sequence;
 use FG\ASN1\Universal\Set;
-use FG\ASN1\Universal\Null;
+use FG\ASN1\Universal\NullObject;
 use FG\ASN1\Universal\PrintableString;
 use FG\ASN1\Universal\ObjectIdentifier;
 
@@ -33,7 +33,7 @@ class DocumentationExamplesTest extends ASN1TestCase
         $enum = new Enumerated(1);
         $ia5String = new IA5String('Hello world');
 
-        $asnNull = new Null();
+        $asnNull = new NullObject();
         $objectIdentifier1 = new ObjectIdentifier('1.2.250.1.16.9');
         $objectIdentifier2 = new ObjectIdentifier(OID::RSA_ENCRYPTION);
         $printableString = new PrintableString('Foo bar');


### PR DESCRIPTION
* `FG\ASN1\Universal\Null` renamed into `FG\ASN1\Universal\NullObject`
* `FG\ASN1\Universal\Null` is now an empty class that extends `FG\ASN1\Universal\NullObject`
* Tests configuration updated
* Documentation updated

Fixes #34.
Please note that this commit may break compatibility and could require to bump to a major release