### PR TITLE
Attempt at biginteger support

### DIFF
--- a/lib/ASN1/Universal/Integer.php
+++ b/lib/ASN1/Universal/Integer.php
@@ -56,7 +56,7 @@ class Integer extends Object implements Parsable
     private function rightShift($number, $positions)
     {
         // Shift 1 right = div / 2
-        return gmp_strval(gmp_div($number, gmp_pow(2, (int)$positions)));
+        return gmp_div($number, gmp_pow(2, (int)$positions));
     }
 
     protected function getEncodedValue()
@@ -80,8 +80,7 @@ class Integer extends Object implements Parsable
 
     public static function fromBinary(&$binaryData, &$offsetIndex = 0)
     {
-        $parsedObject = new static(0);
-        self::parseIdentifier($binaryData[$offsetIndex], $parsedObject->getType(), $offsetIndex++);
+        self::parseIdentifier($binaryData[$offsetIndex], static::getType(), $offsetIndex++);
         $contentLength = self::parseContentLength($binaryData, $offsetIndex, 1);
 
         $isNegative = (ord($binaryData[$offsetIndex]) & 0x80) != 0x00;
@@ -96,7 +95,7 @@ class Integer extends Object implements Parsable
             $number = gmp_sub($number, gmp_pow(2, 8*$contentLength-1));
         }
 
-        $parsedObject->value = gmp_strval($number);
+        $parsedObject = new static(gmp_strval($number, 10));
         $parsedObject->setContentLength($contentLength);
 
         return $parsedObject;

--- a/lib/ASN1/Universal/Integer.php
+++ b/lib/ASN1/Universal/Integer.php
@@ -51,7 +51,7 @@ class Integer extends Object implements Parsable
     protected function calculateContentLength()
     {
         $nrOfOctets = 1; // we need at least one octet
-        $tmpValue = gmp_abs($this->value);
+        $tmpValue = gmp_abs(gmp_init($this->value));
         while (gmp_cmp($tmpValue, 127) > 0) {
             $tmpValue = $this->rightShift($tmpValue, 8);
             $nrOfOctets++;

--- a/lib/ASN1/Universal/Integer.php
+++ b/lib/ASN1/Universal/Integer.php
@@ -85,7 +85,8 @@ class Integer extends Object implements Parsable
 
     public static function fromBinary(&$binaryData, &$offsetIndex = 0)
     {
-        self::parseIdentifier($binaryData[$offsetIndex], static::getType(), $offsetIndex++);
+        $parsedObject = new static(0);
+        self::parseIdentifier($binaryData[$offsetIndex], $parsedObject->getType(), $offsetIndex++);
         $contentLength = self::parseContentLength($binaryData, $offsetIndex, 1);
 
         $isNegative = (ord($binaryData[$offsetIndex]) & 0x80) != 0x00;

--- a/lib/ASN1/Universal/Integer.php
+++ b/lib/ASN1/Universal/Integer.php
@@ -42,15 +42,20 @@ class Integer extends Object implements Parsable
         return $this->value;
     }
 
+    public function rightShift($number, $positions)
+    {
+        // Shift 1 right = div / 2
+        return gmp_strval(gmp_div($number, gmp_pow(2, (int)$positions)));
+    }
+
     protected function calculateContentLength()
     {
         $nrOfOctets = 1; // we need at least one octet
-        $tmpValue = abs($this->value);
-        while ($tmpValue > 127) {
-            $tmpValue = $tmpValue >> 8;
+        $tmpValue = gmp_abs($this->value);
+        while (gmp_cmp($tmpValue, 127) > 0) {
+            $tmpValue = $this->rightShift($tmpValue, 8);
             $nrOfOctets++;
         }
-
         return $nrOfOctets;
     }
 
@@ -60,14 +65,13 @@ class Integer extends Object implements Parsable
         $contentLength = $this->getContentLength();
 
         if ($numericValue < 0) {
-            $numericValue = abs($numericValue);
-            $numericValue = ~$numericValue & (pow(2, 8 * $contentLength) - 1);
-            $numericValue += 1;
+            $numericValue = gmp_add($numericValue, (gmp_sub(gmp_pow(2, 8 * $contentLength), 1)));
+            $numericValue = gmp_add($numericValue, 1);
         }
 
         $result = '';
         for ($shiftLength = ($contentLength-1)*8; $shiftLength >= 0; $shiftLength -= 8) {
-            $octet = $numericValue >> $shiftLength;
+            $octet = gmp_strval(gmp_mod($this->rightShift($numericValue, $shiftLength), 256));
             $result .= chr($octet);
         }
 

--- a/lib/ASN1/Universal/Integer.php
+++ b/lib/ASN1/Universal/Integer.php
@@ -42,16 +42,10 @@ class Integer extends Object implements Parsable
         return $this->value;
     }
 
-    public function rightShift($number, $positions)
-    {
-        // Shift 1 right = div / 2
-        return gmp_strval(gmp_div($number, gmp_pow(2, (int)$positions)));
-    }
-
     protected function calculateContentLength()
     {
         $nrOfOctets = 1; // we need at least one octet
-        $tmpValue = gmp_abs(gmp_init($this->value));
+        $tmpValue = gmp_abs(gmp_init($this->value, 10));
         while (gmp_cmp($tmpValue, 127) > 0) {
             $tmpValue = $this->rightShift($tmpValue, 8);
             $nrOfOctets++;
@@ -59,12 +53,18 @@ class Integer extends Object implements Parsable
         return $nrOfOctets;
     }
 
+    private function rightShift($number, $positions)
+    {
+        // Shift 1 right = div / 2
+        return gmp_strval(gmp_div($number, gmp_pow(2, (int)$positions)));
+    }
+
     protected function getEncodedValue()
     {
-        $numericValue = $this->value;
+        $numericValue = gmp_init($this->value, 10);
         $contentLength = $this->getContentLength();
 
-        if ($numericValue < 0) {
+        if (gmp_sign($numericValue) < 0) {
             $numericValue = gmp_add($numericValue, (gmp_sub(gmp_pow(2, 8 * $contentLength), 1)));
             $numericValue = gmp_add($numericValue, 1);
         }
@@ -86,7 +86,7 @@ class Integer extends Object implements Parsable
 
         $isNegative = (ord($binaryData[$offsetIndex]) & 0x80) != 0x00;
 
-        $number = gmp_init(ord($binaryData[$offsetIndex++]) & 0x7F);
+        $number = gmp_init(ord($binaryData[$offsetIndex++]) & 0x7F, 10);
 
         for ($i = 0; $i<$contentLength-1; $i++) {
             $number = gmp_or(gmp_mul($number, 0x100), ord($binaryData[$offsetIndex++]));

--- a/lib/ASN1/Universal/Integer.php
+++ b/lib/ASN1/Universal/Integer.php
@@ -53,6 +53,11 @@ class Integer extends Object implements Parsable
         return $nrOfOctets;
     }
 
+    /**
+     * @param resource|\GMP $number
+     * @param int $positions
+     * @return resource|\GMP
+     */
     private function rightShift($number, $positions)
     {
         // Shift 1 right = div / 2

--- a/lib/ASN1/Universal/Integer.php
+++ b/lib/ASN1/Universal/Integer.php
@@ -93,7 +93,7 @@ class Integer extends Object implements Parsable
         }
 
         if ($isNegative) {
-            $number = gmp_sub($number, pow(2, 8*$contentLength-1));
+            $number = gmp_sub($number, gmp_pow(2, 8*$contentLength-1));
         }
 
         $parsedObject->value = gmp_strval($number);

--- a/tests/ASN1/Universal/IntegerTest.php
+++ b/tests/ASN1/Universal/IntegerTest.php
@@ -145,6 +145,7 @@ class IntegerTest extends ASN1TestCase
 
     public function testBigIntegerSupport()
     {
+        // Positive bigint
         $expectedType     = chr(Identifier::INTEGER);
         $expectedLength   = chr(0x20);
         $expectedContent  = "\x7f\xff\xff\xff\xff\xff\xff\xff";
@@ -153,6 +154,20 @@ class IntegerTest extends ASN1TestCase
         $expectedContent .= "\xff\xff\xff\xff\xff\xff\xff\xff";
 
         $bigint = gmp_strval(gmp_sub(gmp_pow(2, 255), 1));
+        $object = new Integer($bigint);
+        $binary = $object->getBinary();
+        $this->assertEquals($expectedType.$expectedLength.$expectedContent, $binary);
+
+        $obj = Object::fromBinary($binary);
+        $this->assertEquals($obj, $object);
+
+        // Test a negative number
+        $expectedLength   = chr(0x21);
+        $expectedContent  = "\x00\x80\x00\x00\x00\x00\x00\x00\x00";
+        $expectedContent .= "\x00\x00\x00\x00\x00\x00\x00\x00";
+        $expectedContent .= "\x00\x00\x00\x00\x00\x00\x00\x00";
+        $expectedContent .= "\x00\x00\x00\x00\x00\x00\x00\x00";
+        $bigint = gmp_strval(gmp_pow(2, 255));
         $object = new Integer($bigint);
         $binary = $object->getBinary();
         $this->assertEquals($expectedType.$expectedLength.$expectedContent, $binary);

--- a/tests/ASN1/Universal/IntegerTest.php
+++ b/tests/ASN1/Universal/IntegerTest.php
@@ -30,6 +30,14 @@ class IntegerTest extends ASN1TestCase
         $this->assertEquals(chr(Identifier::INTEGER), $object->getIdentifier());
     }
 
+    /**
+     * @expectedException \Exception
+     */
+    public function testCreateInstanceCanFail()
+    {
+        new Integer('a');
+    }
+
     public function testContent()
     {
         $object = new Integer(1234);

--- a/tests/ASN1/Universal/IntegerTest.php
+++ b/tests/ASN1/Universal/IntegerTest.php
@@ -10,6 +10,7 @@
 
 namespace FG\Test\ASN1\Universal;
 
+use FG\ASN1\Object;
 use FG\Test\ASN1TestCase;
 use FG\ASN1\Identifier;
 use FG\ASN1\Universal\Integer;
@@ -139,6 +140,25 @@ class IntegerTest extends ASN1TestCase
         $expectedContent .= chr(0x25);
         $expectedContent .= chr(0x44);
         $this->assertEquals($expectedType.$expectedLength.$expectedContent, $object->getBinary());
+
+    }
+
+    public function testBigIntegerSupport()
+    {
+        $expectedType     = chr(Identifier::INTEGER);
+        $expectedLength   = chr(0x20);
+        $expectedContent  = "\x7f\xff\xff\xff\xff\xff\xff\xff";
+        $expectedContent .= "\xff\xff\xff\xff\xff\xff\xff\xff";
+        $expectedContent .= "\xff\xff\xff\xff\xff\xff\xff\xff";
+        $expectedContent .= "\xff\xff\xff\xff\xff\xff\xff\xff";
+
+        $bigint = gmp_strval(gmp_sub(gmp_pow(2, 255), 1));
+        $object = new Integer($bigint);
+        $binary = $object->getBinary();
+        $this->assertEquals($expectedType.$expectedLength.$expectedContent, $binary);
+
+        $obj = Object::fromBinary($binary);
+        $this->assertEquals($obj, $object);
     }
 
     /**

--- a/tests/ASN1/Universal/IntegerTest.php
+++ b/tests/ASN1/Universal/IntegerTest.php
@@ -181,7 +181,7 @@ class IntegerTest extends ASN1TestCase
         $this->assertEquals($expectedType.$expectedLength.$expectedContent, $binary);
 
         $obj = Object::fromBinary($binary);
-        $this->assertEquals($obj, $object);
+        $this->assertEquals($object, $obj);
     }
 
     public function testRangeOfBigInts()

--- a/tests/ASN1/Universal/IntegerTest.php
+++ b/tests/ASN1/Universal/IntegerTest.php
@@ -184,6 +184,30 @@ class IntegerTest extends ASN1TestCase
         $this->assertEquals($obj, $object);
     }
 
+    public function testRangeOfBigInts()
+    {
+        for ($i = 1; $i < 256; $i *= 2) {
+            // 2 ^ n [0, 256]  large positive numbers
+            $k = gmp_strval(gmp_pow(2, $i), 10);
+            $this->doIntSerializationTest($k);
+        }
+
+        for ($i = 1; $i < 256; $i *= 2) {
+            // 0 - 2 ^ n [0, 256]  large negative numbers
+            $k= gmp_strval(gmp_sub(0, gmp_pow(2, $i)), 10);
+            $this->doIntSerializationTest($k);
+        }
+    }
+
+    private function doIntSerializationTest($k)
+    {
+        $object = new Integer($k);
+        $binary = $object->getBinary();
+
+        $obj = Object::fromBinary($binary);
+        $this->assertEquals($obj->getContent(), $object->getContent());
+    }
+
     /**
      * @depends testGetBinary
      */

--- a/tests/ASN1/Universal/IntegerTest.php
+++ b/tests/ASN1/Universal/IntegerTest.php
@@ -186,13 +186,13 @@ class IntegerTest extends ASN1TestCase
 
     public function testRangeOfBigInts()
     {
-        for ($i = 1; $i < 256; $i *= 2) {
+        for ($i = 1; $i <= 256; $i *= 2) {
             // 2 ^ n [0, 256]  large positive numbers
             $k = gmp_strval(gmp_pow(2, $i), 10);
             $this->doIntSerializationTest($k);
         }
 
-        for ($i = 1; $i < 256; $i *= 2) {
+        for ($i = 1; $i <= 256; $i *= 2) {
             // 0 - 2 ^ n [0, 256]  large negative numbers
             $k= gmp_strval(gmp_sub(0, gmp_pow(2, $i)), 10);
             $this->doIntSerializationTest($k);


### PR DESCRIPTION
I was trying to serialize an elliptic curve prime as an Integer with this library, but I noticed whenever I provide this (as a string - the result of gmp_strval), use of pure PHP math operators in the Integer class winds up casting the value as an integer, which is limited by PHP_INT_MAX. https://github.com/fgrosse/PHPASN1/blob/master/lib/ASN1/Universal/Integer.php#L62-71

Note that this problem of initializing with the wrong value doesn't happen when parsing structures from elsewhere, since using GMP allows for arbitrarily sized integers. https://github.com/fgrosse/PHPASN1/blob/master/lib/ASN1/Universal/Integer.php#L85-95

I have a sort of working attempt here and a test for it also. It's a shame that PHP doesn't support arbitrarily sized integers yet :/ 

Anyways, it would be nice to support writing these integers somehow! 