### PR TITLE
Arbitrary integer size Base128

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "fgrosse/phpasn1",
+    "name": "afk11/phpasn1",
     "description": "A PHP Framework that allows you to encode and decode arbitrary ASN.1 structures using the ITU-T X.690 Encoding Rules.",
     "type": "library",
     "homepage": "https://github.com/FGrosse/PHPASN1",

--- a/lib/ASN1/Base128.php
+++ b/lib/ASN1/Base128.php
@@ -15,13 +15,19 @@ class Base128
      */
     public static function encode($value)
     {
-        $octets = chr($value & 0x7F);
-        $value >>= 7;
+        $value = gmp_init($value, 10);
+        $octets = chr(gmp_strval(gmp_and($value, 0x7f), 10));
 
-        while ($value > 0) {
-            $octets .= chr(0x80 | ($value & 0x7F));
-            $value >>= 7;
+        $rshift = function ($number, $positions) {
+            return gmp_div($number, gmp_pow(2, (int)$positions));
+        };
+
+        $value = $rshift($value, 7);
+        while (gmp_cmp($value, 0) > 0) {
+            $octets .= chr(gmp_strval(gmp_or(0x80, gmp_and($value, 0x7f)), 10));
+            $value = $rshift($value, 7);
         }
+
         return strrev($octets);
     }
 

--- a/lib/ASN1/Universal/Integer.php
+++ b/lib/ASN1/Universal/Integer.php
@@ -51,7 +51,7 @@ class Integer extends Object implements Parsable
     protected function calculateContentLength()
     {
         $nrOfOctets = 1; // we need at least one octet
-        $tmpValue = gmp_abs($this->value);
+        $tmpValue = gmp_abs(gmp_init($this->value));
         while (gmp_cmp($tmpValue, 127) > 0) {
             $tmpValue = $this->rightShift($tmpValue, 8);
             $nrOfOctets++;

--- a/lib/ASN1/Universal/Integer.php
+++ b/lib/ASN1/Universal/Integer.php
@@ -42,15 +42,20 @@ class Integer extends Object implements Parsable
         return $this->value;
     }
 
+    public function rightShift($number, $positions)
+    {
+        // Shift 1 right = div / 2
+        return gmp_strval(gmp_div($number, gmp_pow(2, (int)$positions)));
+    }
+
     protected function calculateContentLength()
     {
         $nrOfOctets = 1; // we need at least one octet
-        $tmpValue = abs($this->value);
-        while ($tmpValue > 127) {
-            $tmpValue = $tmpValue >> 8;
+        $tmpValue = gmp_abs($this->value);
+        while (gmp_cmp($tmpValue, 127) > 0) {
+            $tmpValue = $this->rightShift($tmpValue, 8);
             $nrOfOctets++;
         }
-
         return $nrOfOctets;
     }
 
@@ -60,14 +65,13 @@ class Integer extends Object implements Parsable
         $contentLength = $this->getContentLength();
 
         if ($numericValue < 0) {
-            $numericValue = abs($numericValue);
-            $numericValue = ~$numericValue & (pow(2, 8 * $contentLength) - 1);
-            $numericValue += 1;
+            $numericValue = gmp_add($numericValue, (gmp_sub(gmp_pow(2, 8 * $contentLength), 1)));
+            $numericValue = gmp_add($numericValue, 1);
         }
 
         $result = '';
         for ($shiftLength = ($contentLength-1)*8; $shiftLength >= 0; $shiftLength -= 8) {
-            $octet = $numericValue >> $shiftLength;
+            $octet = gmp_strval(gmp_mod($this->rightShift($numericValue, $shiftLength), 256));
             $result .= chr($octet);
         }
 

--- a/tests/ASN1/Base128Test.php
+++ b/tests/ASN1/Base128Test.php
@@ -86,13 +86,4 @@ class Base128Test extends \PHPUnit_Framework_TestCase
     {
         Base128::decode("\xFF\xFF");
     }
-
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Value (0xFFFFFFFFFFFFFFFFFFFF7F) exceeds the maximum integer length when base128-decoded.
-     */
-    public function testDecodeFailsIfOverflows()
-    {
-        Base128::decode("\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x7F");
-    }
 }

--- a/tests/ASN1/Universal/IntegerTest.php
+++ b/tests/ASN1/Universal/IntegerTest.php
@@ -145,6 +145,7 @@ class IntegerTest extends ASN1TestCase
 
     public function testBigIntegerSupport()
     {
+        // Positive bigint
         $expectedType     = chr(Identifier::INTEGER);
         $expectedLength   = chr(0x20);
         $expectedContent  = "\x7f\xff\xff\xff\xff\xff\xff\xff";
@@ -153,6 +154,20 @@ class IntegerTest extends ASN1TestCase
         $expectedContent .= "\xff\xff\xff\xff\xff\xff\xff\xff";
 
         $bigint = gmp_strval(gmp_sub(gmp_pow(2, 255), 1));
+        $object = new Integer($bigint);
+        $binary = $object->getBinary();
+        $this->assertEquals($expectedType.$expectedLength.$expectedContent, $binary);
+
+        $obj = Object::fromBinary($binary);
+        $this->assertEquals($obj, $object);
+
+        // Test a negative number
+        $expectedLength   = chr(0x21);
+        $expectedContent  = "\x00\x80\x00\x00\x00\x00\x00\x00\x00";
+        $expectedContent .= "\x00\x00\x00\x00\x00\x00\x00\x00";
+        $expectedContent .= "\x00\x00\x00\x00\x00\x00\x00\x00";
+        $expectedContent .= "\x00\x00\x00\x00\x00\x00\x00\x00";
+        $bigint = gmp_strval(gmp_pow(2, 255));
         $object = new Integer($bigint);
         $binary = $object->getBinary();
         $this->assertEquals($expectedType.$expectedLength.$expectedContent, $binary);

--- a/tests/ASN1/Universal/IntegerTest.php
+++ b/tests/ASN1/Universal/IntegerTest.php
@@ -10,6 +10,7 @@
 
 namespace FG\Test\ASN1\Universal;
 
+use FG\ASN1\Object;
 use FG\Test\ASN1TestCase;
 use FG\ASN1\Identifier;
 use FG\ASN1\Universal\Integer;
@@ -139,6 +140,25 @@ class IntegerTest extends ASN1TestCase
         $expectedContent .= chr(0x25);
         $expectedContent .= chr(0x44);
         $this->assertEquals($expectedType.$expectedLength.$expectedContent, $object->getBinary());
+
+    }
+
+    public function testBigIntegerSupport()
+    {
+        $expectedType     = chr(Identifier::INTEGER);
+        $expectedLength   = chr(0x20);
+        $expectedContent  = "\x7f\xff\xff\xff\xff\xff\xff\xff";
+        $expectedContent .= "\xff\xff\xff\xff\xff\xff\xff\xff";
+        $expectedContent .= "\xff\xff\xff\xff\xff\xff\xff\xff";
+        $expectedContent .= "\xff\xff\xff\xff\xff\xff\xff\xff";
+
+        $bigint = gmp_strval(gmp_sub(gmp_pow(2, 255), 1));
+        $object = new Integer($bigint);
+        $binary = $object->getBinary();
+        $this->assertEquals($expectedType.$expectedLength.$expectedContent, $binary);
+
+        $obj = Object::fromBinary($binary);
+        $this->assertEquals($obj, $object);
     }
 
     /**


### PR DESCRIPTION
quick PR since I saw #37 - this modifies Base128 to use GMP, supporting arbitrary sized integers. 