### PR TITLE
Rewrite Base128 to use GMP

### DIFF
--- a/lib/ASN1/Base128.php
+++ b/lib/ASN1/Base128.php
@@ -15,13 +15,19 @@ class Base128
      */
     public static function encode($value)
     {
-        $octets = chr($value & 0x7F);
-        $value >>= 7;
+        $value = gmp_init($value, 10);
+        $octets = chr(gmp_strval(gmp_and($value, 0x7f), 10));
 
-        while ($value > 0) {
-            $octets .= chr(0x80 | ($value & 0x7F));
-            $value >>= 7;
+        $rightShift = function ($number, $positions) {
+            return gmp_div($number, gmp_pow(2, (int)$positions));
+        };
+
+        $value = $rightShift($value, 7);
+        while (gmp_cmp($value, 0) > 0) {
+            $octets .= chr(gmp_strval(gmp_or(0x80, gmp_and($value, 0x7f)), 10));
+            $value = $rightShift($value, 7);
         }
+
         return strrev($octets);
     }
 
@@ -33,30 +39,30 @@ class Base128
      */
     public static function decode($octets)
     {
-        $bitsMax = (PHP_INT_SIZE * 8) - 1;
-        $bitsUsed = 0;
         $bitsPerOctet = 7;
-        $value = 0;
+        $value = gmp_init(0, 10);
         $i = 0;
+
+        $leftShift = function ($number, $positions) {
+            return gmp_mul($number, gmp_pow(2, (int)$positions));
+        };
 
         while (true) {
             if (!isset($octets[$i])) {
                 throw new InvalidArgumentException(sprintf('Malformed base-128 encoded value (0x%s).', strtoupper(bin2hex($octets)) ?: '0'));
             }
 
-            $bitsUsed += $bitsPerOctet;
-            if ($bitsUsed > $bitsMax) {
-                throw new InvalidArgumentException(sprintf('Value (0x%s) exceeds the maximum integer length when base128-decoded.', strtoupper(bin2hex($octets))));
-            }
+            $octet = gmp_init(ord($octets[$i++]), 10);
 
-            $octet = ord($octets[$i++]);
-            $value = ($value << $bitsPerOctet) + ($octet & 0x7F);
+            $l1 = $leftShift($value, $bitsPerOctet);
+            $r1 = gmp_and($octet, 0x7f);
+            $value = gmp_add($l1, $r1);
 
-            if (0 === ($octet & 0x80)) {
+            if (0 === gmp_cmp(gmp_and($octet, 0x80), 0)) {
                 break;
             }
         }
 
-        return $value;
+        return gmp_strval($value);
     }
 }

--- a/tests/ASN1/Base128Test.php
+++ b/tests/ASN1/Base128Test.php
@@ -87,12 +87,4 @@ class Base128Test extends \PHPUnit_Framework_TestCase
         Base128::decode("\xFF\xFF");
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Value (0xFFFFFFFFFFFFFFFFFFFF7F) exceeds the maximum integer length when base128-decoded.
-     */
-    public function testDecodeFailsIfOverflows()
-    {
-        Base128::decode("\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x7F");
-    }
 }


### PR DESCRIPTION
Re #37 

Removes the constraint that integers must be < PHP_INT_MAX. Removed this check and corresponding test. 