### PR TITLE
test for invalid input

### DIFF
--- a/lib/ASN1/ExplicitlyTaggedObject.php
+++ b/lib/ASN1/ExplicitlyTaggedObject.php
@@ -95,7 +95,7 @@ class ExplicitlyTaggedObject extends Object
         $decoratedObject = Object::fromBinary($binaryData, $offsetIndex);
         $decoratedObjectLength = $decoratedObject->getObjectLength();
         if ($decoratedObjectLength != $contentLength) {
-            throw new ParserException("Context-Specific explicitly tagged object [$tag] starting at offset $offsetIndexOfDecoratedObject is ".($decoratedObjectLength < $contentLength ? 'shorter than required' : 'longer than allowed')." in the outer tag", $offsetIndexOfDecoratedObject);
+            throw new ParserException("Context-Specific explicitly tagged object [$tag] starting at offset $offsetIndexOfDecoratedObject is ".($decoratedObjectLength < $contentLength ? 'shorter than required' : 'longer than allowed').' in the outer tag', $offsetIndexOfDecoratedObject);
         }
 
         $parsedObject = new self($tag, $decoratedObject);

--- a/lib/ASN1/ExplicitlyTaggedObject.php
+++ b/lib/ASN1/ExplicitlyTaggedObject.php
@@ -93,8 +93,9 @@ class ExplicitlyTaggedObject extends Object
         $contentLength = self::parseContentLength($binaryData, $offsetIndex);
         $offsetIndexOfDecoratedObject = $offsetIndex;
         $decoratedObject = Object::fromBinary($binaryData, $offsetIndex);
-        if ($decoratedObject->getObjectLength() != $contentLength) {
-            throw new ParserException("Context-Specific explicitly tagged object [$tag] starting at offset $offsetIndexOfDecoratedObject is longer than allowed in the outer tag", $offsetIndexOfDecoratedObject);
+        $decoratedObjectLength = $decoratedObject->getObjectLength();
+        if ($decoratedObjectLength != $contentLength) {
+            throw new ParserException("Context-Specific explicitly tagged object [$tag] starting at offset $offsetIndexOfDecoratedObject is ".($decoratedObjectLength < $contentLength ? 'shorter than required' : 'longer than allowed')." in the outer tag", $offsetIndexOfDecoratedObject);
         }
 
         $parsedObject = new self($tag, $decoratedObject);

--- a/lib/ASN1/Object.php
+++ b/lib/ASN1/Object.php
@@ -289,7 +289,7 @@ abstract class Object implements Parsable
     protected static function parseBinaryIdentifier($binaryData, &$offsetIndex)
     {
         if (strlen($binaryData) <= $offsetIndex) {
-            throw new ParserException('Can not parse binary identifier from data: Offset index larger than input size', $offsetIndex);
+            throw new ParserException('Can not parse identifier from data: Offset index larger than input size', $offsetIndex);
         }
 
         $identifier = $binaryData[$offsetIndex++];
@@ -300,7 +300,7 @@ abstract class Object implements Parsable
 
         while (true) {
             if (strlen($binaryData) <= $offsetIndex) {
-                throw new ParserException('Can not parse binary identifier from data: Offset index larger than input size', $offsetIndex);
+                throw new ParserException('Can not parse identifier (long form) from data: Offset index larger than input size', $offsetIndex);
             }
             $nextOctet = $binaryData[$offsetIndex++];
             $identifier .= $nextOctet;

--- a/lib/ASN1/Object.php
+++ b/lib/ASN1/Object.php
@@ -202,7 +202,7 @@ abstract class Object implements Parsable
      */
     public static function fromBinary(&$binaryData, &$offsetIndex = 0)
     {
-        if (strlen($binaryData) < $offsetIndex) {
+        if (strlen($binaryData) <= $offsetIndex) {
             throw new ParserException('Can not parse binary from data: Offset index larger than input size', $offsetIndex);
         }
 
@@ -288,6 +288,10 @@ abstract class Object implements Parsable
 
     protected static function parseBinaryIdentifier($binaryData, &$offsetIndex)
     {
+        if (strlen($binaryData) <= $offsetIndex) {
+            throw new ParserException('Can not parse binary identifier from data: Offset index larger than input size', $offsetIndex);
+        }
+
         $identifier = $binaryData[$offsetIndex++];
 
         if (Identifier::isLongForm(ord($identifier)) == false) {
@@ -295,6 +299,9 @@ abstract class Object implements Parsable
         }
 
         while (true) {
+            if (strlen($binaryData) <= $offsetIndex) {
+                throw new ParserException('Can not parse binary identifier from data: Offset index larger than input size', $offsetIndex);
+            }
             $nextOctet = $binaryData[$offsetIndex++];
             $identifier .= $nextOctet;
 
@@ -309,13 +316,19 @@ abstract class Object implements Parsable
 
     protected static function parseContentLength(&$binaryData, &$offsetIndex, $minimumLength = 0)
     {
-        $contentLength = ord($binaryData[$offsetIndex++]);
+        if (strlen($binaryData) <= $offsetIndex) {
+            throw new ParserException('Can not parse content length from data: Offset index larger than input size', $offsetIndex);
+        }
 
+        $contentLength = ord($binaryData[$offsetIndex++]);
         if (($contentLength & 0x80) != 0) {
             // bit 8 is set -> this is the long form
             $nrOfLengthOctets = $contentLength & 0x7F;
             $contentLength = 0x00;
             for ($i = 0; $i < $nrOfLengthOctets; $i++) {
+                if (strlen($binaryData) <= $offsetIndex) {
+                    throw new ParserException('Can not parse content length (long form) from data: Offset index larger than input size', $offsetIndex);
+                }
                 $contentLength = ($contentLength << 8) + ord($binaryData[$offsetIndex++]);
             }
         }

--- a/tests/ASN1/ExplicitlyTaggedObjectTest.php
+++ b/tests/ASN1/ExplicitlyTaggedObjectTest.php
@@ -11,11 +11,12 @@
 namespace FG\Test\ASN1;
 
 use FG\ASN1\Identifier;
+use FG\ASN1\Object;
 use FG\Test\ASN1TestCase;
 use FG\ASN1\ExplicitlyTaggedObject;
 use FG\ASN1\Universal\PrintableString;
 
-class ExplicitlyTaggedConstructTest extends ASN1TestCase
+class ExplicitlyTaggedObjectTest extends ASN1TestCase
 {
     public function testGetType()
     {

--- a/tests/ASN1/ExplicitlyTaggedObjectTest.php
+++ b/tests/ASN1/ExplicitlyTaggedObjectTest.php
@@ -88,4 +88,28 @@ class ExplicitlyTaggedObjectTest extends ASN1TestCase
             [0x00004002],
         ];
     }
+
+    /**
+     * @expectedException \FG\ASN1\Exception\ParserException
+     * @expectedExceptionMessage ASN.1 Parser Exception at offset 2: Context-Specific explicitly tagged object [1] starting at offset 2 is shorter than required in the outer tag
+     * @depends testFromBinary
+     */
+    public function testFromBinaryExTagObjWithInvalidOuterLengthThrowsException1()
+    {
+        $data = hex2bin('a104040101');
+        //                  ^- this is wrong. correct would be "3"
+        Object::fromBinary($data);
+    }
+
+    /**
+     * @expectedException \FG\ASN1\Exception\ParserException
+     * @expectedExceptionMessage ASN.1 Parser Exception at offset 2: Context-Specific explicitly tagged object [1] starting at offset 2 is longer than allowed in the outer tag
+     * @depends testFromBinary
+     */
+    public function testFromBinaryExTagObjWithInvalidOuterLengthThrowsException2()
+    {
+        $data = hex2bin('a102040101');
+        //                  ^- this is wrong. correct would be "3"
+        Object::fromBinary($data);
+    }
 }

--- a/tests/ASN1/ObjectTest.php
+++ b/tests/ASN1/ObjectTest.php
@@ -230,4 +230,94 @@ class ObjectTest extends ASN1TestCase
         $offset = 10;
         Object::fromBinary($binaryData, $offset);
     }
+
+    /**
+     * @expectedException \FG\ASN1\Exception\ParserException
+     * @expectedExceptionMessage ASN.1 Parser Exception at offset 0: Can not parse binary from data: Offset index larger than input size
+     * @depends testFromBinary
+     */
+    public function testFromBinaryWithEmptyStringThrowsException()
+    {
+        $data = "";
+        Object::fromBinary($data);
+    }
+
+    /**
+     * @expectedException \FG\ASN1\Exception\ParserException
+     * @expectedExceptionMessage ASN.1 Parser Exception at offset 2: Can not parse binary from data: Offset index larger than input size
+     * @depends testFromBinary
+     */
+    public function testFromBinaryWithSpacyStringThrowsException()
+    {
+        $data = "  ";
+        Object::fromBinary($data);
+    }
+
+    /**
+     * @expectedException \FG\ASN1\Exception\ParserException
+     * @expectedExceptionMessage ASN.1 Parser Exception at offset 1: Can not parse content length from data: Offset index larger than input size
+     * @depends testFromBinary
+     */
+    public function testFromBinaryWithNumberStringThrowsException()
+    {
+        $data = "1";
+        Object::fromBinary($data);
+    }
+
+    /**
+     * @expectedException \FG\ASN1\Exception\ParserException
+     * @expectedExceptionMessage ASN.1 Parser Exception at offset 25: Can not parse content length from data: Offset index larger than input size
+     * @depends testFromBinary
+     */
+    public function testFromBinaryWithGarbageStringThrowsException()
+    {
+        $data = "certainly no asn.1 object";
+        Object::fromBinary($data);
+    }
+
+    /**
+     * @expectedException \FG\ASN1\Exception\ParserException
+     * @expectedExceptionMessage ASN.1 Parser Exception at offset 2: Context-Specific explicitly tagged object [1] starting at offset 2 is shorter than required in the outer tag
+     * @depends testFromBinary
+     */
+    public function testFromBinaryExTagObjWithInvalidOuterLengthThrowsException1() {
+        $data = hex2bin("a104040101");
+        //                  ^- this is wrong. correct would be "3"
+        Object::fromBinary($data);
+    }
+
+    /**
+     * @expectedException \FG\ASN1\Exception\ParserException
+     * @expectedExceptionMessage ASN.1 Parser Exception at offset 2: Context-Specific explicitly tagged object [1] starting at offset 2 is shorter than required in the outer tag
+     * @depends testFromBinary
+     */
+    public function testFromBinaryExTagObjWithInvalidOuterLengthThrowsException2() {
+        $data = hex2bin("a105040101");
+        //                  ^- this is wrong. correct would be "3"
+        Object::fromBinary($data);
+    }
+
+    /**
+     * @expectedException \FG\ASN1\Exception\ParserException
+     * @expectedExceptionMessage ASN.1 Parser Exception at offset 1: Can not parse binary identifier from data: Offset index larger than input size
+     * @depends testFromBinary
+     */
+    public function testFromBinaryUnknownObjectMissingLength() {
+        $data = hex2bin("1f");
+        Object::fromBinary($data);
+    }
+
+    /**
+     * @expectedException \FG\ASN1\Exception\ParserException
+     * @expectedExceptionMessage ASN.1 Parser Exception at offset 4: Can not parse content length (long form) from data: Offset index larger than input size
+     * @depends testFromBinary
+     */
+    public function testFromBinaryInalidLongFormContentLength() {
+        $binaryData  = chr(Identifier::INTEGER);
+        $binaryData .= chr(0x8f); //denotes a long-form content length with 15 length-octets
+        $binaryData .= chr(0x1);  //only give one content-length-octet
+        $binaryData .= chr(0x1);  //this is needed to reach the code to be tested
+
+        Object::fromBinary($binaryData);
+    }
 }

--- a/tests/ASN1/ObjectTest.php
+++ b/tests/ASN1/ObjectTest.php
@@ -277,7 +277,7 @@ class ObjectTest extends ASN1TestCase
 
     /**
      * @expectedException \FG\ASN1\Exception\ParserException
-     * @expectedExceptionMessage ASN.1 Parser Exception at offset 1: Can not parse binary identifier from data: Offset index larger than input size
+     * @expectedExceptionMessage ASN.1 Parser Exception at offset 1: Can not parse identifier (long form) from data: Offset index larger than input size
      * @depends testFromBinary
      */
     public function testFromBinaryUnknownObjectMissingLength()

--- a/tests/ASN1/ObjectTest.php
+++ b/tests/ASN1/ObjectTest.php
@@ -277,30 +277,6 @@ class ObjectTest extends ASN1TestCase
 
     /**
      * @expectedException \FG\ASN1\Exception\ParserException
-     * @expectedExceptionMessage ASN.1 Parser Exception at offset 2: Context-Specific explicitly tagged object [1] starting at offset 2 is shorter than required in the outer tag
-     * @depends testFromBinary
-     */
-    public function testFromBinaryExTagObjWithInvalidOuterLengthThrowsException1()
-    {
-        $data = hex2bin('a104040101');
-        //                  ^- this is wrong. correct would be "3"
-        Object::fromBinary($data);
-    }
-
-    /**
-     * @expectedException \FG\ASN1\Exception\ParserException
-     * @expectedExceptionMessage ASN.1 Parser Exception at offset 2: Context-Specific explicitly tagged object [1] starting at offset 2 is shorter than required in the outer tag
-     * @depends testFromBinary
-     */
-    public function testFromBinaryExTagObjWithInvalidOuterLengthThrowsException2()
-    {
-        $data = hex2bin('a105040101');
-        //                  ^- this is wrong. correct would be "3"
-        Object::fromBinary($data);
-    }
-
-    /**
-     * @expectedException \FG\ASN1\Exception\ParserException
      * @expectedExceptionMessage ASN.1 Parser Exception at offset 1: Can not parse binary identifier from data: Offset index larger than input size
      * @depends testFromBinary
      */

--- a/tests/ASN1/ObjectTest.php
+++ b/tests/ASN1/ObjectTest.php
@@ -238,7 +238,7 @@ class ObjectTest extends ASN1TestCase
      */
     public function testFromBinaryWithEmptyStringThrowsException()
     {
-        $data = "";
+        $data = '';
         Object::fromBinary($data);
     }
 
@@ -249,7 +249,7 @@ class ObjectTest extends ASN1TestCase
      */
     public function testFromBinaryWithSpacyStringThrowsException()
     {
-        $data = "  ";
+        $data = '  ';
         Object::fromBinary($data);
     }
 
@@ -260,7 +260,7 @@ class ObjectTest extends ASN1TestCase
      */
     public function testFromBinaryWithNumberStringThrowsException()
     {
-        $data = "1";
+        $data = '1';
         Object::fromBinary($data);
     }
 
@@ -271,7 +271,7 @@ class ObjectTest extends ASN1TestCase
      */
     public function testFromBinaryWithGarbageStringThrowsException()
     {
-        $data = "certainly no asn.1 object";
+        $data = 'certainly no asn.1 object';
         Object::fromBinary($data);
     }
 
@@ -280,8 +280,9 @@ class ObjectTest extends ASN1TestCase
      * @expectedExceptionMessage ASN.1 Parser Exception at offset 2: Context-Specific explicitly tagged object [1] starting at offset 2 is shorter than required in the outer tag
      * @depends testFromBinary
      */
-    public function testFromBinaryExTagObjWithInvalidOuterLengthThrowsException1() {
-        $data = hex2bin("a104040101");
+    public function testFromBinaryExTagObjWithInvalidOuterLengthThrowsException1()
+    {
+        $data = hex2bin('a104040101');
         //                  ^- this is wrong. correct would be "3"
         Object::fromBinary($data);
     }
@@ -291,8 +292,9 @@ class ObjectTest extends ASN1TestCase
      * @expectedExceptionMessage ASN.1 Parser Exception at offset 2: Context-Specific explicitly tagged object [1] starting at offset 2 is shorter than required in the outer tag
      * @depends testFromBinary
      */
-    public function testFromBinaryExTagObjWithInvalidOuterLengthThrowsException2() {
-        $data = hex2bin("a105040101");
+    public function testFromBinaryExTagObjWithInvalidOuterLengthThrowsException2()
+    {
+        $data = hex2bin('a105040101');
         //                  ^- this is wrong. correct would be "3"
         Object::fromBinary($data);
     }
@@ -302,8 +304,9 @@ class ObjectTest extends ASN1TestCase
      * @expectedExceptionMessage ASN.1 Parser Exception at offset 1: Can not parse binary identifier from data: Offset index larger than input size
      * @depends testFromBinary
      */
-    public function testFromBinaryUnknownObjectMissingLength() {
-        $data = hex2bin("1f");
+    public function testFromBinaryUnknownObjectMissingLength()
+    {
+        $data = hex2bin('1f');
         Object::fromBinary($data);
     }
 
@@ -312,7 +315,8 @@ class ObjectTest extends ASN1TestCase
      * @expectedExceptionMessage ASN.1 Parser Exception at offset 4: Can not parse content length (long form) from data: Offset index larger than input size
      * @depends testFromBinary
      */
-    public function testFromBinaryInalidLongFormContentLength() {
+    public function testFromBinaryInalidLongFormContentLength()
+    {
         $binaryData  = chr(Identifier::INTEGER);
         $binaryData .= chr(0x8f); //denotes a long-form content length with 15 length-octets
         $binaryData .= chr(0x1);  //only give one content-length-octet


### PR DESCRIPTION
prevent `E_NOTICE` when passing invalid input to `Object::fromBinary` - throw Exception instead