### PR TITLE
Fix mbstring func overload

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The **changelog** can now be found at [CHANGELOG.md](CHANGELOG.md).
 
 ## Dependencies
 
-PHPASN1 requires at least `PHP 5.6` and the `gmp` extension.
+PHPASN1 requires at least `PHP 5.6` and the following extensions: `gmp` and `mbstring`.
 It has also been successfully tested using `PHP 7` and `HHVM`
 For the loading of object identifier names directly from the web [curl][7] is used.
 

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
 
     "require": {
         "php": ">=5.6.0",
-        "ext-gmp": "*"
+        "ext-gmp": "*",
+        "ext-mbstring": "*"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.5",

--- a/lib/ASN1/AbstractString.php
+++ b/lib/ASN1/AbstractString.php
@@ -85,7 +85,7 @@ abstract class AbstractString extends Object implements Parsable
 
     protected function calculateContentLength()
     {
-        return strlen($this->value);
+        return mb_strlen($this->value, '8bit');
     }
 
     protected function getEncodedValue()
@@ -114,7 +114,7 @@ abstract class AbstractString extends Object implements Parsable
 
         self::parseIdentifier($binaryData[$offsetIndex], $parsedObject->getType(), $offsetIndex++);
         $contentLength = self::parseContentLength($binaryData, $offsetIndex);
-        $string = substr($binaryData, $offsetIndex, $contentLength);
+        $string = mb_substr($binaryData, $offsetIndex, $contentLength, '8bit');
         $offsetIndex += $contentLength;
 
         $parsedObject->value = $string;

--- a/lib/ASN1/AbstractTime.php
+++ b/lib/ASN1/AbstractTime.php
@@ -51,7 +51,7 @@ abstract class AbstractTime extends Object
             $messages .= "{$errorMessage}, ";
         }
 
-        return substr($messages, 0, -2);
+        return mb_substr($messages, 0, -2, '8bit');
     }
 
     public function __toString()
@@ -62,8 +62,8 @@ abstract class AbstractTime extends Object
     protected static function extractTimeZoneData(&$binaryData, &$offsetIndex, DateTime $dateTime)
     {
         $sign = $binaryData[$offsetIndex++];
-        $timeOffsetHours   = intval(substr($binaryData, $offsetIndex, 2));
-        $timeOffsetMinutes = intval(substr($binaryData, $offsetIndex + 2, 2));
+        $timeOffsetHours   = intval(mb_substr($binaryData, $offsetIndex, 2, '8bit'));
+        $timeOffsetMinutes = intval(mb_substr($binaryData, $offsetIndex + 2, 2, '8bit'));
         $offsetIndex += 4;
 
         $interval = new DateInterval("PT{$timeOffsetHours}H{$timeOffsetMinutes}M");

--- a/lib/ASN1/Identifier.php
+++ b/lib/ASN1/Identifier.php
@@ -297,7 +297,7 @@ class Identifier
         if (is_numeric($identifier)) {
             $identifier = chr($identifier);
         }
-        return Base128::decode(substr($identifier, 1));
+        return Base128::decode(mb_substr($identifier, 1, null, '8bit'));
     }
 
     public static function isUniversalClass($identifier)

--- a/lib/ASN1/Object.php
+++ b/lib/ASN1/Object.php
@@ -170,7 +170,7 @@ abstract class Object implements Parsable
      */
     public function getObjectLength()
     {
-        $nrOfIdentifierOctets = strlen($this->getIdentifier());
+        $nrOfIdentifierOctets = mb_strlen($this->getIdentifier(), '8bit');
         $contentLength = $this->getContentLength();
         $nrOfLengthOctets = $this->getNumberOfLengthOctets($contentLength);
 
@@ -202,7 +202,7 @@ abstract class Object implements Parsable
      */
     public static function fromBinary(&$binaryData, &$offsetIndex = 0)
     {
-        if (strlen($binaryData) <= $offsetIndex) {
+        if (mb_strlen($binaryData, '8bit') <= $offsetIndex) {
             throw new ParserException('Can not parse binary from data: Offset index larger than input size', $offsetIndex);
         }
 
@@ -288,7 +288,7 @@ abstract class Object implements Parsable
 
     protected static function parseBinaryIdentifier($binaryData, &$offsetIndex)
     {
-        if (strlen($binaryData) <= $offsetIndex) {
+        if (mb_strlen($binaryData, '8bit') <= $offsetIndex) {
             throw new ParserException('Can not parse identifier from data: Offset index larger than input size', $offsetIndex);
         }
 
@@ -299,7 +299,7 @@ abstract class Object implements Parsable
         }
 
         while (true) {
-            if (strlen($binaryData) <= $offsetIndex) {
+            if (mb_strlen($binaryData, '8bit') <= $offsetIndex) {
                 throw new ParserException('Can not parse identifier (long form) from data: Offset index larger than input size', $offsetIndex);
             }
             $nextOctet = $binaryData[$offsetIndex++];
@@ -316,7 +316,7 @@ abstract class Object implements Parsable
 
     protected static function parseContentLength(&$binaryData, &$offsetIndex, $minimumLength = 0)
     {
-        if (strlen($binaryData) <= $offsetIndex) {
+        if (mb_strlen($binaryData, '8bit') <= $offsetIndex) {
             throw new ParserException('Can not parse content length from data: Offset index larger than input size', $offsetIndex);
         }
 
@@ -326,7 +326,7 @@ abstract class Object implements Parsable
             $nrOfLengthOctets = $contentLength & 0x7F;
             $contentLength = 0x00;
             for ($i = 0; $i < $nrOfLengthOctets; $i++) {
-                if (strlen($binaryData) <= $offsetIndex) {
+                if (mb_strlen($binaryData, '8bit') <= $offsetIndex) {
                     throw new ParserException('Can not parse content length (long form) from data: Offset index larger than input size', $offsetIndex);
                 }
                 $contentLength = ($contentLength << 8) + ord($binaryData[$offsetIndex++]);

--- a/lib/ASN1/Universal/BitString.php
+++ b/lib/ASN1/Universal/BitString.php
@@ -68,7 +68,7 @@ class BitString extends OctetString implements Parsable
         $contentLength = self::parseContentLength($binaryData, $offsetIndex, 2);
 
         $nrOfUnusedBits = ord($binaryData[$offsetIndex]);
-        $value = substr($binaryData, $offsetIndex + 1, $contentLength - 1);
+        $value = mb_substr($binaryData, $offsetIndex + 1, $contentLength - 1, '8bit');
         $offsetIndex += $contentLength;
 
         $parsedObject = new self(bin2hex($value), $nrOfUnusedBits);

--- a/lib/ASN1/Universal/GeneralizedTime.php
+++ b/lib/ASN1/Universal/GeneralizedTime.php
@@ -50,7 +50,7 @@ class GeneralizedTime extends AbstractTime implements Parsable
         $contentSize = 15; // YYYYMMDDHHmmSSZ
 
         if ($this->containsFractionalSecondsElement()) {
-            $contentSize += 1 + strlen($this->microseconds);
+            $contentSize += 1 + mb_strlen($this->microseconds, '8bit');
         }
 
         return $contentSize;
@@ -88,8 +88,8 @@ class GeneralizedTime extends AbstractTime implements Parsable
         $maximumBytesToRead = $contentLength;
 
         $format = 'YmdGis';
-        $content = substr($binaryData, $offsetIndex, $contentLength);
-        $dateTimeString = substr($content, 0, $lengthOfMinimumTimeString);
+        $content = mb_substr($binaryData, $offsetIndex, $contentLength, '8bit');
+        $dateTimeString = mb_substr($content, 0, $lengthOfMinimumTimeString, '8bit');
         $offsetIndex += $lengthOfMinimumTimeString;
         $maximumBytesToRead -= $lengthOfMinimumTimeString;
 
@@ -109,7 +109,7 @@ class GeneralizedTime extends AbstractTime implements Parsable
                     $maximumBytesToRead--;
                 }
 
-                $dateTimeString .= substr($binaryData, $offsetIndex, $nrOfFractionalSecondElements);
+                $dateTimeString .= mb_substr($binaryData, $offsetIndex, $nrOfFractionalSecondElements, '8bit');
                 $offsetIndex += $nrOfFractionalSecondElements;
                 $format .= '.u';
             }

--- a/lib/ASN1/Universal/ObjectIdentifier.php
+++ b/lib/ASN1/Universal/ObjectIdentifier.php
@@ -133,6 +133,6 @@ class ObjectIdentifier extends Object implements Parsable
         }
 
         // Remove trailing '.'
-        return substr($oid, 0, -1) ?: '';
+        return mb_substr($oid, 0, -1, '8bit') ?: '';
     }
 }

--- a/lib/ASN1/Universal/OctetString.php
+++ b/lib/ASN1/Universal/OctetString.php
@@ -32,7 +32,7 @@ class OctetString extends Object implements Parsable
             throw new Exception('OctetString: unrecognized input type!');
         }
 
-        if (strlen($value) % 2 != 0) {
+        if (mb_strlen($value, '8bit') % 2 != 0) {
             // transform values like 1F2 to 01F2
             $value = '0'.$value;
         }
@@ -47,7 +47,7 @@ class OctetString extends Object implements Parsable
 
     protected function calculateContentLength()
     {
-        return strlen($this->value) / 2;
+        return mb_strlen($this->value, '8bit') / 2;
     }
 
     protected function getEncodedValue()
@@ -56,10 +56,10 @@ class OctetString extends Object implements Parsable
         $result = '';
 
         //Actual content
-        while (strlen($value) >= 2) {
+        while (mb_strlen($value, '8bit') >= 2) {
             // get the hex value byte by byte from the string and and add it to binary result
-            $result .= chr(hexdec(substr($value, 0, 2)));
-            $value = substr($value, 2);
+            $result .= chr(hexdec(mb_substr($value, 0, 2, '8bit')));
+            $value = mb_substr($value, 2, null, '8bit');
         }
 
         return $result;
@@ -80,7 +80,7 @@ class OctetString extends Object implements Parsable
         self::parseIdentifier($binaryData[$offsetIndex], Identifier::OCTETSTRING, $offsetIndex++);
         $contentLength = self::parseContentLength($binaryData, $offsetIndex);
 
-        $value = substr($binaryData, $offsetIndex, $contentLength);
+        $value = mb_substr($binaryData, $offsetIndex, $contentLength, '8bit');
         $offsetIndex += $contentLength;
 
         $parsedObject = new self(bin2hex($value));

--- a/lib/ASN1/Universal/UTCTime.php
+++ b/lib/ASN1/Universal/UTCTime.php
@@ -47,14 +47,14 @@ class UTCTime extends AbstractTime implements Parsable
         $contentLength = self::parseContentLength($binaryData, $offsetIndex, 11);
 
         $format = 'ymdGi';
-        $dateTimeString = substr($binaryData, $offsetIndex, 10);
+        $dateTimeString = mb_substr($binaryData, $offsetIndex, 10, '8bit');
         $offsetIndex += 10;
 
         // extract optional seconds part
         if ($binaryData[$offsetIndex] != 'Z'
         && $binaryData[$offsetIndex] != '+'
         && $binaryData[$offsetIndex] != '-') {
-            $dateTimeString .= substr($binaryData, $offsetIndex, 2);
+            $dateTimeString .= mb_substr($binaryData, $offsetIndex, 2, '8bit');
             $offsetIndex += 2;
             $format .= 's';
         }

--- a/lib/X509/CSR/CSR.php
+++ b/lib/X509/CSR/CSR.php
@@ -77,9 +77,9 @@ class CSR extends Sequence
     {
         $tmp = base64_encode($this->getBinary());
 
-        for ($i = 0; $i < strlen($tmp); $i++) {
+        for ($i = 0; $i < mb_strlen($tmp, '8bit'); $i++) {
             if (($i + 2) % 65 == 0) {
-                $tmp = substr($tmp, 0, $i + 1)."\n".substr($tmp, $i + 1);
+                $tmp = mb_substr($tmp, 0, $i + 1, '8bit')."\n".mb_substr($tmp, $i + 1, null, '8bit');
             }
         }
 

--- a/tests/ASN1/ObjectTest.php
+++ b/tests/ASN1/ObjectTest.php
@@ -109,7 +109,7 @@ class ObjectTest extends ASN1TestCase
         /* @var IA5String $parsedObject */
         $string = 'Hello Foo World!!!11EinsEins!1';
         $binaryData = chr(Identifier::IA5_STRING);
-        $binaryData .= chr(strlen($string));
+        $binaryData .= chr(mb_strlen($string, '8bit'));
         $binaryData .= $string;
 
         $expectedObject = new IA5String($string);
@@ -150,7 +150,7 @@ class ObjectTest extends ASN1TestCase
         /* @var PrintableString $parsedObject */
         $string = 'This is a test string. #?!%&""';
         $binaryData = chr(Identifier::PRINTABLE_STRING);
-        $binaryData .= chr(strlen($string));
+        $binaryData .= chr(mb_strlen($string, '8bit'));
         $binaryData .= $string;
 
         $expectedObject = new PrintableString($string);

--- a/tests/ASN1/Universal/BMPStringTest.php
+++ b/tests/ASN1/Universal/BMPStringTest.php
@@ -38,7 +38,7 @@ class BMPStringTest extends ASN1TestCase
     {
         $string = 'Hello World';
         $object = new BMPString($string);
-        $expectedSize = 2 + strlen($string);
+        $expectedSize = 2 + mb_strlen($string, '8bit');
         $this->assertEquals($expectedSize, $object->getObjectLength());
     }
 
@@ -46,7 +46,7 @@ class BMPStringTest extends ASN1TestCase
     {
         $string = 'Hello World';
         $expectedType = chr(Identifier::BMP_STRING);
-        $expectedLength = chr(strlen($string));
+        $expectedLength = chr(mb_strlen($string, '8bit'));
 
         $object = new BMPString($string);
         $this->assertEquals($expectedType.$expectedLength.$string, $object->getBinary());

--- a/tests/ASN1/Universal/CharacterStringTest.php
+++ b/tests/ASN1/Universal/CharacterStringTest.php
@@ -38,7 +38,7 @@ class CharacterStringTest extends ASN1TestCase
     {
         $string = 'Hello World';
         $object = new CharacterString($string);
-        $expectedSize = 2 + strlen($string);
+        $expectedSize = 2 + mb_strlen($string, '8bit');
         $this->assertEquals($expectedSize, $object->getObjectLength());
     }
 
@@ -46,7 +46,7 @@ class CharacterStringTest extends ASN1TestCase
     {
         $string = 'Hello World';
         $expectedType = chr(Identifier::CHARACTER_STRING);
-        $expectedLength = chr(strlen($string));
+        $expectedLength = chr(mb_strlen($string, '8bit'));
 
         $object = new CharacterString($string);
         $this->assertEquals($expectedType.$expectedLength.$string, $object->getBinary());

--- a/tests/ASN1/Universal/GeneralStringTest.php
+++ b/tests/ASN1/Universal/GeneralStringTest.php
@@ -44,7 +44,7 @@ class GeneralStringTest extends ASN1TestCase
     {
         $string = 'Hello World';
         $object = new GeneralString($string);
-        $expectedSize = 2 + strlen($string);
+        $expectedSize = 2 + mb_strlen($string, '8bit');
         $this->assertEquals($expectedSize, $object->getObjectLength());
     }
 
@@ -52,7 +52,7 @@ class GeneralStringTest extends ASN1TestCase
     {
         $string = 'Hello World';
         $expectedType = chr(Identifier::GENERAL_STRING);
-        $expectedLength = chr(strlen($string));
+        $expectedLength = chr(mb_strlen($string, '8bit'));
 
         $object = new GeneralString($string);
         $this->assertEquals($expectedType.$expectedLength.$string, $object->getBinary());

--- a/tests/ASN1/Universal/GraphicStringTest.php
+++ b/tests/ASN1/Universal/GraphicStringTest.php
@@ -44,7 +44,7 @@ class GraphicStringTest extends ASN1TestCase
     {
         $string = 'Hello World';
         $object = new GraphicString($string);
-        $expectedSize = 2 + strlen($string);
+        $expectedSize = 2 + mb_strlen($string, '8bit');
         $this->assertEquals($expectedSize, $object->getObjectLength());
     }
 
@@ -52,7 +52,7 @@ class GraphicStringTest extends ASN1TestCase
     {
         $string = 'Hello World';
         $expectedType = chr(Identifier::GRAPHIC_STRING);
-        $expectedLength = chr(strlen($string));
+        $expectedLength = chr(mb_strlen($string, '8bit'));
 
         $object = new GraphicString($string);
         $this->assertEquals($expectedType.$expectedLength.$string, $object->getBinary());

--- a/tests/ASN1/Universal/IA5StringTest.php
+++ b/tests/ASN1/Universal/IA5StringTest.php
@@ -44,7 +44,7 @@ class IA5StringTest extends ASN1TestCase
     {
         $string = 'Hello World';
         $object = new IA5String($string);
-        $expectedSize = 2 + strlen($string);
+        $expectedSize = 2 + mb_strlen($string, '8bit');
         $this->assertEquals($expectedSize, $object->getObjectLength());
     }
 
@@ -52,7 +52,7 @@ class IA5StringTest extends ASN1TestCase
     {
         $string = 'Hello World';
         $expectedType = chr(Identifier::IA5_STRING);
-        $expectedLength = chr(strlen($string));
+        $expectedLength = chr(mb_strlen($string, '8bit'));
 
         $object = new IA5String($string);
         $this->assertEquals($expectedType.$expectedLength.$string, $object->getBinary());

--- a/tests/ASN1/Universal/NumericStringTest.php
+++ b/tests/ASN1/Universal/NumericStringTest.php
@@ -41,7 +41,7 @@ class NumericStringTest extends ASN1TestCase
     {
         $string = '123  4 55677 0987';
         $object = new NumericString($string);
-        $expectedSize = 2 + strlen($string);
+        $expectedSize = 2 + mb_strlen($string, '8bit');
         $this->assertEquals($expectedSize, $object->getObjectLength());
     }
 
@@ -49,7 +49,7 @@ class NumericStringTest extends ASN1TestCase
     {
         $string = '123  4 55677 0987';
         $expectedType = chr(Identifier::NUMERIC_STRING);
-        $expectedLength = chr(strlen($string));
+        $expectedLength = chr(mb_strlen($string, '8bit'));
 
         $object = new NumericString($string);
         $this->assertEquals($expectedType.$expectedLength.$string, $object->getBinary());

--- a/tests/ASN1/Universal/ObjectDescriptorTest.php
+++ b/tests/ASN1/Universal/ObjectDescriptorTest.php
@@ -38,7 +38,7 @@ class ObjectDescriptorTest extends ASN1TestCase
     {
         $string = 'Basic Encoding of a single ASN.1 type';
         $object = new ObjectDescriptor($string);
-        $expectedSize = 2 + strlen($string);
+        $expectedSize = 2 + mb_strlen($string, '8bit');
         $this->assertEquals($expectedSize, $object->getObjectLength());
     }
 
@@ -46,7 +46,7 @@ class ObjectDescriptorTest extends ASN1TestCase
     {
         $string = 'Basic Encoding of a single ASN.1 type';
         $expectedType = chr(Identifier::OBJECT_DESCRIPTOR);
-        $expectedLength = chr(strlen($string));
+        $expectedLength = chr(mb_strlen($string, '8bit'));
 
         $object = new ObjectDescriptor($string);
         $this->assertEquals($expectedType.$expectedLength.$string, $object->getBinary());

--- a/tests/ASN1/Universal/PrintableStringTest.php
+++ b/tests/ASN1/Universal/PrintableStringTest.php
@@ -44,7 +44,7 @@ class PrintableStringTest extends ASN1TestCase
     {
         $string = 'Hello World';
         $object = new PrintableString($string);
-        $expectedSize = 2 + strlen($string);
+        $expectedSize = 2 + mb_strlen($string, '8bit');
         $this->assertEquals($expectedSize, $object->getObjectLength());
     }
 
@@ -52,7 +52,7 @@ class PrintableStringTest extends ASN1TestCase
     {
         $string = 'Hello World';
         $expectedType = chr(Identifier::PRINTABLE_STRING);
-        $expectedLength = chr(strlen($string));
+        $expectedLength = chr(mb_strlen($string, '8bit'));
 
         $object = new PrintableString($string);
         $this->assertEquals($expectedType.$expectedLength.$string, $object->getBinary());

--- a/tests/ASN1/Universal/T61StringTest.php
+++ b/tests/ASN1/Universal/T61StringTest.php
@@ -38,7 +38,7 @@ class T61StringTest extends ASN1TestCase
     {
         $string = 'Hello World';
         $object = new T61String($string);
-        $expectedSize = 2 + strlen($string);
+        $expectedSize = 2 + mb_strlen($string, '8bit');
         $this->assertEquals($expectedSize, $object->getObjectLength());
     }
 
@@ -46,7 +46,7 @@ class T61StringTest extends ASN1TestCase
     {
         $string = 'Hello World';
         $expectedType = chr(Identifier::T61_STRING);
-        $expectedLength = chr(strlen($string));
+        $expectedLength = chr(mb_strlen($string, '8bit'));
 
         $object = new T61String($string);
         $this->assertEquals($expectedType.$expectedLength.$string, $object->getBinary());

--- a/tests/ASN1/Universal/UTF8StringTest.php
+++ b/tests/ASN1/Universal/UTF8StringTest.php
@@ -38,7 +38,7 @@ class UTF8StringTest extends ASN1TestCase
     {
         $string = 'Hello World';
         $object = new UTF8String($string);
-        $expectedSize = 2 + strlen($string);
+        $expectedSize = 2 + mb_strlen($string, '8bit');
         $this->assertEquals($expectedSize, $object->getObjectLength());
     }
 
@@ -46,7 +46,7 @@ class UTF8StringTest extends ASN1TestCase
     {
         $string = 'Hello World';
         $expectedType = chr(Identifier::UTF8_STRING);
-        $expectedLength = chr(strlen($string));
+        $expectedLength = chr(mb_strlen($string, '8bit'));
 
         $object = new UTF8String($string);
         $this->assertEquals($expectedType.$expectedLength.$string, $object->getBinary());

--- a/tests/ASN1/Universal/UniversalStringTest.php
+++ b/tests/ASN1/Universal/UniversalStringTest.php
@@ -38,7 +38,7 @@ class UniversalStringTest extends ASN1TestCase
     {
         $string = 'Hello World';
         $object = new UniversalString($string);
-        $expectedSize = 2 + strlen($string);
+        $expectedSize = 2 + mb_strlen($string, '8bit');
         $this->assertEquals($expectedSize, $object->getObjectLength());
     }
 
@@ -46,7 +46,7 @@ class UniversalStringTest extends ASN1TestCase
     {
         $string = 'Hello World';
         $expectedType = chr(Identifier::UNIVERSAL_STRING);
-        $expectedLength = chr(strlen($string));
+        $expectedLength = chr(mb_strlen($string, '8bit'));
 
         $object = new UniversalString($string);
         $this->assertEquals($expectedType.$expectedLength.$string, $object->getBinary());

--- a/tests/ASN1/Universal/VisibleStringTest.php
+++ b/tests/ASN1/Universal/VisibleStringTest.php
@@ -44,7 +44,7 @@ class VisibleStringTest extends ASN1TestCase
     {
         $string = 'Hello World';
         $object = new VisibleString($string);
-        $expectedSize = 2 + strlen($string);
+        $expectedSize = 2 + mb_strlen($string, '8bit');
         $this->assertEquals($expectedSize, $object->getObjectLength());
     }
 
@@ -52,7 +52,7 @@ class VisibleStringTest extends ASN1TestCase
     {
         $string = 'Hello World';
         $expectedType = chr(Identifier::VISIBLE_STRING);
-        $expectedLength = chr(strlen($string));
+        $expectedLength = chr(mb_strlen($string, '8bit'));
 
         $object = new VisibleString($string);
         $this->assertEquals($expectedType.$expectedLength.$string, $object->getBinary());

--- a/tests/X509/DNSNameTest.php
+++ b/tests/X509/DNSNameTest.php
@@ -37,7 +37,7 @@ class DNSNameTest extends ASN1TestCase
     {
         $string = 'test.corvespace.de';
         $object = new DNSName($string);
-        $expectedSize = 2 + strlen($string);
+        $expectedSize = 2 + mb_strlen($string, '8bit');
         $this->assertEquals($expectedSize, $object->getObjectLength());
     }
 
@@ -45,7 +45,7 @@ class DNSNameTest extends ASN1TestCase
     {
         $string = 'test.corvespace.de';
         $expectedType = chr(0x82);
-        $expectedLength = chr(strlen($string));
+        $expectedLength = chr(mb_strlen($string, '8bit'));
 
         $object = new DNSName($string);
         $this->assertEquals($expectedType.$expectedLength.$string, $object->getBinary());


### PR DESCRIPTION
`PHPASN1` is a dependancy of `web-push-php`. Some of my users have `mbstring.func_overload` set and thus the library is (in part) broken because of some uses of strlen and substr in PHPASN1.

This PR replaces strlen and substr occurences with their unicode safe counterpart (mb_strlen and mb_substr).

Cf. https://github.com/web-push-libs/web-push-php/issues/79