### PR TITLE
added .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+/examples           export-ignore
+/tests              export-ignore
+/.gitattributes     export-ignore
+/.gitignore         export-ignore
+/.travis.yml        export-ignore
+/.coveralls.yml     export-ignore
+/.styleci.yml       export-ignore
+/phpunit.xml.dist   export-ignore


### PR DESCRIPTION
would be great if we wouldn't get the examples and tests via composer, when installing with --prefer-dist.

for background see https://www.reddit.com/r/PHP/comments/2jzp6k/i_dont_need_your_tests_in_my_production/