### PR TITLE
Rename Object to ASNObject to ensure both PHP 5.6 and PHP 7.2 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### v.1.6.0 (2018-05-16)
+* fix PHP 7.2 compatibility
+
 #### v.1.5.2 (2016-10-29)
 * allow empty octet strings
 

--- a/examples/Issue14.php
+++ b/examples/Issue14.php
@@ -12,7 +12,7 @@ require_once __DIR__.'/../vendor/autoload.php';
 require_once 'shared.php';
 
 use FG\ASN1\OID;
-use FG\ASN1\Object;
+use FG\ASN1\ASNObject;
 use FG\ASN1\Identifier;
 use FG\ASN1\Universal\ObjectIdentifier;
 use FG\ASN1\Universal\OctetString;
@@ -67,7 +67,7 @@ try {
     $binaryData = base64_decode($base64);
     //hexdump($binaryData, false);
 
-    $rootObject = Object::fromBinary($binaryData);
+    $rootObject = ASNObject::fromBinary($binaryData);
     //printObject($rootObject);
 
     // first navigate to the certificate extensions
@@ -86,7 +86,7 @@ try {
     $certExtensions = $certInfoFields[7];
 
     // check if this is really the certificate extensions sequence
-    /* @var \FG\ASN1\Object $certExtensions */
+    /* @var \FG\ASN1\ASNObject $certExtensions */
     $certExtensionsType = $certExtensions->getType();
     assert(Identifier::isContextSpecificClass($certExtensionsType));
     assert(Identifier::getTagNumber($certExtensions->getType()) == 3);
@@ -96,7 +96,7 @@ try {
     assert($certExtensions->getType() == Identifier::SEQUENCE);
 
     // now check all extensions and search for the SAN
-    /** @var \FG\ASN1\Object $extensionSequence */
+    /** @var \FG\ASN1\ASNObject $extensionSequence */
     foreach ($certExtensions as $extensionSequence) {
         assert($extensionSequence->getType() == Identifier::SEQUENCE);
         assert($extensionSequence->getNumberofChildren() >= 2);

--- a/examples/Issue29.php
+++ b/examples/Issue29.php
@@ -8,12 +8,12 @@
  * file that was distributed with this source code.
  */
 
-use FG\ASN1\Object;
+use FG\ASN1\ASNObject;
 
 require_once __DIR__.'/../vendor/autoload.php';
 require_once 'shared.php';
 
 $hex = 'a02b302906092a864886f70d01090e311c301a30180603551d110411300f820d636f72766573706163652e6465';
-$asn = Object::fromBinary(hex2bin($hex));
+$asn = ASNObject::fromBinary(hex2bin($hex));
 
 printObject($asn);

--- a/examples/Issue57.php
+++ b/examples/Issue57.php
@@ -9,7 +9,7 @@
  */
 
 use FG\ASN1\ExplicitlyTaggedObject;
-use FG\ASN1\Object;
+use FG\ASN1\ASNObject;
 use FG\ASN1\Universal\Enumerated;
 use FG\ASN1\Universal\ObjectIdentifier;
 use FG\ASN1\Universal\Sequence;
@@ -84,7 +84,7 @@ qXDFVov9UZ+sGy8CJ5ahII79yrfKpxY=
 
 try {
     echo 'Input 1:' . PHP_EOL;
-    printObject(Object::fromBinary(base64_decode($input1)));
+    printObject(ASNObject::fromBinary(base64_decode($input1)));
 } catch (Exception $exception) {
     echo "ERROR: " . $exception->getMessage();
 }
@@ -93,7 +93,7 @@ echo PHP_EOL;
 
 try {
     echo 'Input 2:' . PHP_EOL;
-    printObject(Object::fromBinary(base64_decode($input2)));
+    printObject(ASNObject::fromBinary(base64_decode($input2)));
 } catch (Exception $exception) {
     echo "ERROR: " . $exception->getMessage();
 }
@@ -102,7 +102,7 @@ echo PHP_EOL;
 
 try {
     echo 'Input 3:' . PHP_EOL;
-    printObject(Object::fromBinary(base64_decode($input3)));
+    printObject(ASNObject::fromBinary(base64_decode($input3)));
 } catch (Exception $exception) {
     echo "ERROR: " . $exception->getMessage();
 }

--- a/examples/allClasses.php
+++ b/examples/allClasses.php
@@ -12,7 +12,7 @@ require_once __DIR__.'/hexdump.php';
 require_once __DIR__.'/../vendor/autoload.php';
 
 use FG\ASN1\OID;
-use FG\ASN1\Object;
+use FG\ASN1\ASNObject;
 use FG\ASN1\Universal\Boolean;
 use FG\ASN1\Universal\Integer;
 use FG\ASN1\Universal\Enumerated;
@@ -44,7 +44,7 @@ if (substr($openSSLVersionOutput, 0, 7) == 'OpenSSL') {
     $openSSLisAvailable = false;
 }
 
-function printVariableInfo(Object $variable)
+function printVariableInfo(ASNObject $variable)
 {
     $className = get_class($variable);
     $stringValue = nl2br($variable->__toString());

--- a/examples/parseBinary.php
+++ b/examples/parseBinary.php
@@ -11,7 +11,7 @@
 require_once __DIR__.'/../vendor/autoload.php';
 require_once 'shared.php';
 
-use FG\ASN1\Object;
+use FG\ASN1\ASNObject;
 
 $base64String =
 'MIIFGDCCAwACAQAwOjEWMBQGCgmSJomT8ixkARkWBnNlY3VyZTEgMB4GA1UEAxMX
@@ -44,7 +44,7 @@ secxBTTCNgI48YezK3GDkn65cmlnkt6F6Mf0MwoDaXTuB88Jycbwb5ihKnHEJIsO
 draiRBZruwMPwPIP';
 
 $binaryData = base64_decode($base64String);
-$asnObject = Object::fromBinary($binaryData);
+$asnObject = ASNObject::fromBinary($binaryData);
 
 ?>
 

--- a/examples/shared.php
+++ b/examples/shared.php
@@ -1,9 +1,9 @@
 <?php
 
 use FG\ASN1\Identifier;
-use FG\ASN1\Object;
+use FG\ASN1\ASNObject;
 
-function printObject(Object $object, $depth = 0)
+function printObject(ASNObject $object, $depth = 0)
 {
     $treeSymbol = '';
     $depthString = str_repeat('─', $depth);

--- a/lib/ASN1/ASNObject.php
+++ b/lib/ASN1/ASNObject.php
@@ -40,7 +40,7 @@ use LogicException;
 /**
  * Class Object is the base class for all concrete ASN.1 objects.
  */
-abstract class Object implements Parsable
+abstract class ASNObject implements Parsable
 {
     private $contentLength;
     private $nrOfLengthOctets;
@@ -198,7 +198,7 @@ abstract class Object implements Parsable
      *
      * @throws ParserException
      *
-     * @return \FG\ASN1\Object
+     * @return \FG\ASN1\ASNObject
      */
     public static function fromBinary(&$binaryData, &$offsetIndex = 0)
     {

--- a/lib/ASN1/AbstractString.php
+++ b/lib/ASN1/AbstractString.php
@@ -12,7 +12,7 @@ namespace FG\ASN1;
 
 use Exception;
 
-abstract class AbstractString extends Object implements Parsable
+abstract class AbstractString extends ASNObject implements Parsable
 {
     /** @var string */
     protected $value;

--- a/lib/ASN1/AbstractTime.php
+++ b/lib/ASN1/AbstractTime.php
@@ -15,7 +15,7 @@ use DateTime;
 use DateTimeZone;
 use Exception;
 
-abstract class AbstractTime extends Object
+abstract class AbstractTime extends ASNObject
 {
     /** @var DateTime */
     protected $value;

--- a/lib/ASN1/Composite/AttributeTypeAndValue.php
+++ b/lib/ASN1/Composite/AttributeTypeAndValue.php
@@ -10,7 +10,7 @@
 
 namespace FG\ASN1\Composite;
 
-use FG\ASN1\Object;
+use FG\ASN1\ASNObject;
 use FG\ASN1\Universal\Sequence;
 use FG\ASN1\Universal\ObjectIdentifier;
 
@@ -18,9 +18,9 @@ class AttributeTypeAndValue extends Sequence
 {
     /**
      * @param ObjectIdentifier|string $objIdentifier
-     * @param \FG\ASN1\Object $value
+     * @param \FG\ASN1\ASNObject $value
      */
-    public function __construct($objIdentifier, Object $value)
+    public function __construct($objIdentifier, ASNObject $value)
     {
         if ($objIdentifier instanceof ObjectIdentifier == false) {
             $objIdentifier = new ObjectIdentifier($objIdentifier);

--- a/lib/ASN1/Composite/RDNString.php
+++ b/lib/ASN1/Composite/RDNString.php
@@ -18,7 +18,7 @@ class RDNString extends RelativeDistinguishedName
 {
     /**
      * @param string|\FG\ASN1\Universal\ObjectIdentifier $objectIdentifierString
-     * @param string|\FG\ASN1\Object $value
+     * @param string|\FG\ASN1\ASNObject $value
      */
     public function __construct($objectIdentifierString, $value)
     {

--- a/lib/ASN1/Composite/RelativeDistinguishedName.php
+++ b/lib/ASN1/Composite/RelativeDistinguishedName.php
@@ -11,16 +11,16 @@
 namespace FG\ASN1\Composite;
 
 use FG\ASN1\Exception\NotImplementedException;
-use FG\ASN1\Object;
+use FG\ASN1\ASNObject;
 use FG\ASN1\Universal\Set;
 
 class RelativeDistinguishedName extends Set
 {
     /**
      * @param string|\FG\ASN1\Universal\ObjectIdentifier $objIdentifierString
-     * @param \FG\ASN1\Object $value
+     * @param \FG\ASN1\ASNObject $value
      */
-    public function __construct($objIdentifierString, Object $value)
+    public function __construct($objIdentifierString, ASNObject $value)
     {
         // TODO: This does only support one element in the RelativeDistinguishedName Set but it it is defined as follows:
         // RelativeDistinguishedName ::= SET SIZE (1..MAX) OF AttributeTypeAndValue
@@ -29,7 +29,7 @@ class RelativeDistinguishedName extends Set
 
     public function getContent()
     {
-        /** @var \FG\ASN1\Object $firstObject */
+        /** @var \FG\ASN1\ASNObject $firstObject */
         $firstObject = $this->children[0];
         return $firstObject->__toString();
     }

--- a/lib/ASN1/Construct.php
+++ b/lib/ASN1/Construct.php
@@ -15,14 +15,14 @@ use ArrayIterator;
 use Countable;
 use Iterator;
 
-abstract class Construct extends Object implements Countable, ArrayAccess, Iterator, Parsable
+abstract class Construct extends ASNObject implements Countable, ArrayAccess, Iterator, Parsable
 {
-    /** @var \FG\ASN1\Object[] */
+    /** @var \FG\ASN1\ASNObject[] */
     protected $children;
     private $iteratorPosition;
 
     /**
-     * @param \FG\ASN1\Object[] $children the variadic type hint is commented due to https://github.com/facebook/hhvm/issues/4858
+     * @param \FG\ASN1\ASNObject[] $children the variadic type hint is commented due to https://github.com/facebook/hhvm/issues/4858
      */
     public function __construct(/* HH_FIXME[4858]: variadic + strict */ ...$children)
     {
@@ -104,7 +104,7 @@ abstract class Construct extends Object implements Countable, ArrayAccess, Itera
         return $result;
     }
 
-    public function addChild(Object $child)
+    public function addChild(ASNObject $child)
     {
         $this->children[] = $child;
     }
@@ -130,7 +130,7 @@ abstract class Construct extends Object implements Countable, ArrayAccess, Itera
     }
 
     /**
-     * @return \FG\ASN1\Object[]
+     * @return \FG\ASN1\ASNObject[]
      */
     public function getChildren()
     {
@@ -138,7 +138,7 @@ abstract class Construct extends Object implements Countable, ArrayAccess, Itera
     }
 
     /**
-     * @return \FG\ASN1\Object
+     * @return \FG\ASN1\ASNObject
      */
     public function getFirstChild()
     {
@@ -162,7 +162,7 @@ abstract class Construct extends Object implements Countable, ArrayAccess, Itera
         $children = [];
         $octetsToRead = $contentLength;
         while ($octetsToRead > 0) {
-            $newChild = Object::fromBinary($binaryData, $offsetIndex);
+            $newChild = ASNObject::fromBinary($binaryData, $offsetIndex);
             $octetsToRead -= $newChild->getObjectLength();
             $children[] = $newChild;
         }

--- a/lib/ASN1/ExplicitlyTaggedObject.php
+++ b/lib/ASN1/ExplicitlyTaggedObject.php
@@ -29,15 +29,15 @@ use FG\ASN1\Exception\ParserException;
  *
  * @see http://luca.ntop.org/Teaching/Appunti/asn1.html
  */
-class ExplicitlyTaggedObject extends Object
+class ExplicitlyTaggedObject extends ASNObject
 {
-    /** @var \FG\ASN1\Object[] */
+    /** @var \FG\ASN1\ASNObject[] */
     private $decoratedObjects;
     private $tag;
 
     /**
      * @param int $tag
-     * @param \FG\ASN1\Object $objects,...
+     * @param \FG\ASN1\ASNObject $objects,...
      */
     public function __construct($tag, /* HH_FIXME[4858]: variadic + strict */ ...$objects)
     {
@@ -115,7 +115,7 @@ class ExplicitlyTaggedObject extends Object
         $decoratedObjects = [];
 
         while ($remainingContentLength > 0) {
-            $nextObject = Object::fromBinary($binaryData, $offsetIndex);
+            $nextObject = ASNObject::fromBinary($binaryData, $offsetIndex);
             $remainingContentLength -= $nextObject->getObjectLength();
             $decoratedObjects[] = $nextObject;
         }

--- a/lib/ASN1/TemplateParser.php
+++ b/lib/ASN1/TemplateParser.php
@@ -19,7 +19,7 @@ class TemplateParser
     /**
      * @param string $data
      * @param array $template
-     * @return \FG\ASN1\Object|Sequence
+     * @return \FG\ASN1\ASNObject|Sequence
      * @throws ParserException if there was an issue parsing
      */
     public function parseBase64($data, array $template)
@@ -31,12 +31,12 @@ class TemplateParser
     /**
      * @param string $binary
      * @param array $template
-     * @return \FG\ASN1\Object|Sequence
+     * @return \FG\ASN1\ASNObject|Sequence
      * @throws ParserException if there was an issue parsing
      */
     public function parseBinary($binary, array $template)
     {
-        $parsedObject = Object::fromBinary($binary);
+        $parsedObject = ASNObject::fromBinary($binary);
 
         foreach ($template as $key => $value) {
             $this->validate($parsedObject, $key, $value);
@@ -45,7 +45,7 @@ class TemplateParser
         return $parsedObject;
     }
 
-    private function validate(Object $object, $key, $value)
+    private function validate(ASNObject $object, $key, $value)
     {
         if (is_array($value)) {
             $this->assertTypeId($key, $object);
@@ -60,7 +60,7 @@ class TemplateParser
         }
     }
 
-    private function assertTypeId($expectedTypeId, Object $object)
+    private function assertTypeId($expectedTypeId, ASNObject $object)
     {
         $actualType = $object->getType();
         if ($expectedTypeId != $actualType) {

--- a/lib/ASN1/Universal/Boolean.php
+++ b/lib/ASN1/Universal/Boolean.php
@@ -10,12 +10,12 @@
 
 namespace FG\ASN1\Universal;
 
-use FG\ASN1\Object;
+use FG\ASN1\ASNObject;
 use FG\ASN1\Parsable;
 use FG\ASN1\Identifier;
 use FG\ASN1\Exception\ParserException;
 
-class Boolean extends Object implements Parsable
+class Boolean extends ASNObject implements Parsable
 {
     private $value;
 

--- a/lib/ASN1/Universal/Integer.php
+++ b/lib/ASN1/Universal/Integer.php
@@ -11,11 +11,11 @@
 namespace FG\ASN1\Universal;
 
 use Exception;
-use FG\ASN1\Object;
+use FG\ASN1\ASNObject;
 use FG\ASN1\Parsable;
 use FG\ASN1\Identifier;
 
-class Integer extends Object implements Parsable
+class Integer extends ASNObject implements Parsable
 {
     /** @var int */
     private $value;

--- a/lib/ASN1/Universal/NullObject.php
+++ b/lib/ASN1/Universal/NullObject.php
@@ -10,12 +10,12 @@
 
 namespace FG\ASN1\Universal;
 
-use FG\ASN1\Object;
+use FG\ASN1\ASNObject;
 use FG\ASN1\Parsable;
 use FG\ASN1\Identifier;
 use FG\ASN1\Exception\ParserException;
 
-class NullObject extends Object implements Parsable
+class NullObject extends ASNObject implements Parsable
 {
     public function getType()
     {

--- a/lib/ASN1/Universal/ObjectIdentifier.php
+++ b/lib/ASN1/Universal/ObjectIdentifier.php
@@ -13,12 +13,12 @@ namespace FG\ASN1\Universal;
 use Exception;
 use FG\ASN1\Base128;
 use FG\ASN1\OID;
-use FG\ASN1\Object;
+use FG\ASN1\ASNObject;
 use FG\ASN1\Parsable;
 use FG\ASN1\Identifier;
 use FG\ASN1\Exception\ParserException;
 
-class ObjectIdentifier extends Object implements Parsable
+class ObjectIdentifier extends ASNObject implements Parsable
 {
     protected $subIdentifiers;
     protected $value;

--- a/lib/ASN1/Universal/OctetString.php
+++ b/lib/ASN1/Universal/OctetString.php
@@ -11,11 +11,11 @@
 namespace FG\ASN1\Universal;
 
 use Exception;
-use FG\ASN1\Object;
+use FG\ASN1\ASNObject;
 use FG\ASN1\Parsable;
 use FG\ASN1\Identifier;
 
-class OctetString extends Object implements Parsable
+class OctetString extends ASNObject implements Parsable
 {
     protected $value;
 

--- a/lib/ASN1/UnknownConstructedObject.php
+++ b/lib/ASN1/UnknownConstructedObject.php
@@ -29,7 +29,7 @@ class UnknownConstructedObject extends Construct
         $children = [];
         $octetsToRead = $this->contentLength;
         while ($octetsToRead > 0) {
-            $newChild = Object::fromBinary($binaryData, $offsetIndex);
+            $newChild = ASNObject::fromBinary($binaryData, $offsetIndex);
             $octetsToRead -= $newChild->getObjectLength();
             $children[] = $newChild;
         }

--- a/lib/ASN1/UnknownObject.php
+++ b/lib/ASN1/UnknownObject.php
@@ -10,7 +10,7 @@
 
 namespace FG\ASN1;
 
-class UnknownObject extends Object
+class UnknownObject extends ASNObject
 {
     /** @var string */
     private $value;

--- a/lib/X509/CSR/Attributes.php
+++ b/lib/X509/CSR/Attributes.php
@@ -10,7 +10,7 @@
 
 namespace FG\X509\CSR;
 
-use FG\ASN1\Object;
+use FG\ASN1\ASNObject;
 use FG\X509\CertificateExtensions;
 use FG\ASN1\OID;
 use FG\ASN1\Parsable;
@@ -54,7 +54,7 @@ class Attributes extends Construct implements Parsable
             if ($oidString == OID::PKCS9_EXTENSION_REQUEST) {
                 $attribute = CertificateExtensions::fromBinary($binaryData, $offsetIndex);
             } else {
-                $attribute = Object::fromBinary($binaryData, $offsetIndex);
+                $attribute = ASNObject::fromBinary($binaryData, $offsetIndex);
             }
 
             $parsedObject->addAttribute($objectIdentifier, $attribute);

--- a/lib/X509/CertificateExtensions.php
+++ b/lib/X509/CertificateExtensions.php
@@ -12,7 +12,7 @@ namespace FG\X509;
 
 use FG\ASN1\Exception\ParserException;
 use FG\ASN1\OID;
-use FG\ASN1\Object;
+use FG\ASN1\ASNObject;
 use FG\ASN1\Parsable;
 use FG\ASN1\Identifier;
 use FG\ASN1\Universal\OctetString;
@@ -37,7 +37,7 @@ class CertificateExtensions extends Set implements Parsable
         $this->addExtension(OID::CERT_EXT_SUBJECT_ALT_NAME, $sans);
     }
 
-    private function addExtension($oidString, Object $extension)
+    private function addExtension($oidString, ASNObject $extension)
     {
         $sequence = new Sequence();
         $sequence->addChild(new ObjectIdentifier($oidString));
@@ -73,7 +73,7 @@ class CertificateExtensions extends Set implements Parsable
             if (count($children) < 2) {
                 throw new ParserException('Could not parse Certificate Extensions: Needs at least two child elements per extension sequence (object identifier and octet string)', $tmpOffset);
             }
-            /** @var \FG\ASN1\Object $objectIdentifier */
+            /** @var \FG\ASN1\ASNObject $objectIdentifier */
             $objectIdentifier = $children[0];
 
             /** @var OctetString $octetString */

--- a/lib/X509/PrivateKey.php
+++ b/lib/X509/PrivateKey.php
@@ -20,7 +20,7 @@ class PrivateKey extends Sequence
 {
     /**
      * @param string $hexKey
-     * @param \FG\ASN1\Object|string $algorithmIdentifierString
+     * @param \FG\ASN1\ASNObject|string $algorithmIdentifierString
      */
     public function __construct($hexKey, $algorithmIdentifierString = OID::RSA_ENCRYPTION)
     {

--- a/lib/X509/PublicKey.php
+++ b/lib/X509/PublicKey.php
@@ -20,7 +20,7 @@ class PublicKey extends Sequence
 {
     /**
      * @param string $hexKey
-     * @param \FG\ASN1\Object|string $algorithmIdentifierString
+     * @param \FG\ASN1\ASNObject|string $algorithmIdentifierString
      */
     public function __construct($hexKey, $algorithmIdentifierString = OID::RSA_ENCRYPTION)
     {

--- a/lib/X509/SAN/IPAddress.php
+++ b/lib/X509/SAN/IPAddress.php
@@ -10,11 +10,11 @@
 
 namespace FG\X509\SAN;
 
-use FG\ASN1\Object;
+use FG\ASN1\ASNObject;
 use FG\ASN1\Parsable;
 use FG\ASN1\Exception\ParserException;
 
-class IPAddress extends Object implements Parsable
+class IPAddress extends ASNObject implements Parsable
 {
     const IDENTIFIER = 0x87; // not sure yet why this is the identifier used in SAN extensions
 

--- a/lib/X509/SAN/SubjectAlternativeNames.php
+++ b/lib/X509/SAN/SubjectAlternativeNames.php
@@ -11,7 +11,7 @@
 namespace FG\X509\SAN;
 
 use FG\ASN1\Exception\ParserException;
-use FG\ASN1\Object;
+use FG\ASN1\ASNObject;
 use FG\ASN1\OID;
 use FG\ASN1\Parsable;
 use FG\ASN1\Identifier;
@@ -20,7 +20,7 @@ use FG\ASN1\Universal\Sequence;
 /**
  * See section 8.3.2.1 of ITU-T X.509.
  */
-class SubjectAlternativeNames extends Object implements Parsable
+class SubjectAlternativeNames extends ASNObject implements Parsable
 {
     private $alternativeNamesSequence;
 
@@ -77,7 +77,7 @@ class SubjectAlternativeNames extends Object implements Parsable
         }
 
         $parsedObject = new self();
-        /** @var \FG\ASN1\Object $object */
+        /** @var \FG\ASN1\ASNObject $object */
         foreach ($sequence as $object) {
             if ($object->getType() == DNSName::IDENTIFIER) {
                 $domainName = DNSName::fromBinary($binaryData, $offsetOfSequence);

--- a/tests/ASN1/ObjectTest.php
+++ b/tests/ASN1/ObjectTest.php
@@ -13,7 +13,7 @@ namespace FG\Test\ASN1;
 use FG\ASN1\ExplicitlyTaggedObject;
 use FG\ASN1\Universal\GeneralizedTime;
 use FG\Test\ASN1TestCase;
-use FG\ASN1\Object;
+use FG\ASN1\ASNObject;
 use FG\ASN1\UnknownConstructedObject;
 use FG\ASN1\UnknownObject;
 use FG\ASN1\Identifier;
@@ -32,27 +32,27 @@ class ObjectTest extends ASN1TestCase
 {
     public function testCalculateNumberOfLengthOctets()
     {
-        $object = $this->getMockForAbstractClass('\FG\ASN1\Object');
+        $object = $this->getMockForAbstractClass('\FG\ASN1\ASNObject');
         $calculatedNrOfLengthOctets = $this->callMethod($object, 'getNumberOfLengthOctets', 32);
         $this->assertEquals(1, $calculatedNrOfLengthOctets);
 
-        $object = $this->getMockForAbstractClass('\FG\ASN1\Object');
+        $object = $this->getMockForAbstractClass('\FG\ASN1\ASNObject');
         $calculatedNrOfLengthOctets = $this->callMethod($object, 'getNumberOfLengthOctets', 0);
         $this->assertEquals(1, $calculatedNrOfLengthOctets);
 
-        $object = $this->getMockForAbstractClass('\FG\ASN1\Object');
+        $object = $this->getMockForAbstractClass('\FG\ASN1\ASNObject');
         $calculatedNrOfLengthOctets = $this->callMethod($object, 'getNumberOfLengthOctets', 127);
         $this->assertEquals(1, $calculatedNrOfLengthOctets);
 
-        $object = $this->getMockForAbstractClass('\FG\ASN1\Object');
+        $object = $this->getMockForAbstractClass('\FG\ASN1\ASNObject');
         $calculatedNrOfLengthOctets = $this->callMethod($object, 'getNumberOfLengthOctets', 128);
         $this->assertEquals(2, $calculatedNrOfLengthOctets);
 
-        $object = $this->getMockForAbstractClass('\FG\ASN1\Object');
+        $object = $this->getMockForAbstractClass('\FG\ASN1\ASNObject');
         $calculatedNrOfLengthOctets = $this->callMethod($object, 'getNumberOfLengthOctets', 255);
         $this->assertEquals(2, $calculatedNrOfLengthOctets);
 
-        $object = $this->getMockForAbstractClass('\FG\ASN1\Object');
+        $object = $this->getMockForAbstractClass('\FG\ASN1\ASNObject');
         $calculatedNrOfLengthOctets = $this->callMethod($object, 'getNumberOfLengthOctets', 1025);
         $this->assertEquals(3, $calculatedNrOfLengthOctets);
     }
@@ -70,7 +70,7 @@ class ObjectTest extends ASN1TestCase
         $binaryData .= chr(0xA0);
 
         $expectedObject = new BitString(0xFFA0, 5);
-        $parsedObject = Object::fromBinary($binaryData);
+        $parsedObject = ASNObject::fromBinary($binaryData);
         $this->assertTrue($parsedObject instanceof BitString);
         $this->assertEquals($expectedObject->getContent(), $parsedObject->getContent());
         $this->assertEquals($expectedObject->getNumberOfUnusedBits(), $parsedObject->getNumberOfUnusedBits());
@@ -82,7 +82,7 @@ class ObjectTest extends ASN1TestCase
         $binaryData .= chr(0xA0);
 
         $expectedObject = new OctetString(0xFFA0);
-        $parsedObject = Object::fromBinary($binaryData);
+        $parsedObject = ASNObject::fromBinary($binaryData);
         $this->assertTrue($parsedObject instanceof OctetString);
         $this->assertEquals($expectedObject->getContent(), $parsedObject->getContent());
 
@@ -92,7 +92,7 @@ class ObjectTest extends ASN1TestCase
         $binaryData .= chr(0xFF);
 
         $expectedObject = new Boolean(true);
-        $parsedObject = Object::fromBinary($binaryData);
+        $parsedObject = ASNObject::fromBinary($binaryData);
         $this->assertTrue($parsedObject instanceof Boolean);
         $this->assertEquals($expectedObject->getContent(), $parsedObject->getContent());
 
@@ -102,7 +102,7 @@ class ObjectTest extends ASN1TestCase
         $binaryData .= chr(0x03);
 
         $expectedObject = new Enumerated(3);
-        $parsedObject = Object::fromBinary($binaryData);
+        $parsedObject = ASNObject::fromBinary($binaryData);
         $this->assertTrue($parsedObject instanceof Enumerated);
         $this->assertEquals($expectedObject->getContent(), $parsedObject->getContent());
 
@@ -113,7 +113,7 @@ class ObjectTest extends ASN1TestCase
         $binaryData .= $string;
 
         $expectedObject = new IA5String($string);
-        $parsedObject = Object::fromBinary($binaryData);
+        $parsedObject = ASNObject::fromBinary($binaryData);
         $this->assertTrue($parsedObject instanceof IA5String);
         $this->assertEquals($expectedObject->getContent(), $parsedObject->getContent());
 
@@ -123,7 +123,7 @@ class ObjectTest extends ASN1TestCase
         $binaryData .= chr(123);
 
         $expectedObject = new Integer(123);
-        $parsedObject = Object::fromBinary($binaryData);
+        $parsedObject = ASNObject::fromBinary($binaryData);
         $this->assertTrue($parsedObject instanceof Integer);
         $this->assertEquals($expectedObject->getContent(), $parsedObject->getContent());
 
@@ -132,7 +132,7 @@ class ObjectTest extends ASN1TestCase
         $binaryData .= chr(0x00);
 
         $expectedObject = new NullObject();
-        $parsedObject = Object::fromBinary($binaryData);
+        $parsedObject = ASNObject::fromBinary($binaryData);
         $this->assertTrue($parsedObject instanceof NullObject);
         $this->assertEquals($expectedObject->getContent(), $parsedObject->getContent());
 
@@ -143,7 +143,7 @@ class ObjectTest extends ASN1TestCase
         $binaryData .= chr(3);
 
         $expectedObject = new ObjectIdentifier('1.2.3');
-        $parsedObject = Object::fromBinary($binaryData);
+        $parsedObject = ASNObject::fromBinary($binaryData);
         $this->assertTrue($parsedObject instanceof ObjectIdentifier);
         $this->assertEquals($expectedObject->getContent(), $parsedObject->getContent());
 
@@ -154,7 +154,7 @@ class ObjectTest extends ASN1TestCase
         $binaryData .= $string;
 
         $expectedObject = new PrintableString($string);
-        $parsedObject = Object::fromBinary($binaryData);
+        $parsedObject = ASNObject::fromBinary($binaryData);
         $this->assertTrue($parsedObject instanceof PrintableString);
         $this->assertEquals($expectedObject->getContent(), $parsedObject->getContent());
 
@@ -164,7 +164,7 @@ class ObjectTest extends ASN1TestCase
         $binaryData .= '20120923202316Z';
 
         $expectedObject = new GeneralizedTime('2012-09-23 20:23:16', 'UTC');
-        $parsedObject = Object::fromBinary($binaryData);
+        $parsedObject = ASNObject::fromBinary($binaryData);
         $this->assertTrue($parsedObject instanceof GeneralizedTime);
         $this->assertEquals($expectedObject->getContent(), $parsedObject->getContent());
 
@@ -181,7 +181,7 @@ class ObjectTest extends ASN1TestCase
         $expectedChild1 = new Boolean(false);
         $expectedChild2 = new Integer(0x03);
 
-        $parsedObject = Object::fromBinary($binaryData);
+        $parsedObject = ASNObject::fromBinary($binaryData);
         $this->assertTrue($parsedObject instanceof Sequence);
         $this->assertEquals(2, $parsedObject->getNumberOfChildren());
 
@@ -194,14 +194,14 @@ class ObjectTest extends ASN1TestCase
         /* @var ExplicitlyTaggedObject $parsedObject */
         $taggedObject = new ExplicitlyTaggedObject(0x01, new PrintableString('Hello tagged world'));
         $binaryData = $taggedObject->getBinary();
-        $parsedObject = Object::fromBinary($binaryData);
+        $parsedObject = ASNObject::fromBinary($binaryData);
         $this->assertTrue($parsedObject instanceof ExplicitlyTaggedObject);
 
         // An unknown constructed object containing 2 integer children,
         // first 3 bytes are the identifier.
         $binaryData = "\x3F\x81\x7F\x06".chr(Identifier::INTEGER)."\x01\x42".chr(Identifier::INTEGER)."\x01\x69";
         $offsetIndex = 0;
-        $parsedObject = OBject::fromBinary($binaryData, $offsetIndex);
+        $parsedObject = ASNObject::fromBinary($binaryData, $offsetIndex);
         $this->assertTrue($parsedObject instanceof UnknownConstructedObject);
         $this->assertEquals(substr($binaryData, 0, 3), $parsedObject->getIdentifier());
         $this->assertCount(2, $parsedObject->getContent());
@@ -211,7 +211,7 @@ class ObjectTest extends ASN1TestCase
         // First 3 bytes are the identifier
         $binaryData = "\x1F\x81\x7F\x01\xFF";
         $offsetIndex = 0;
-        $parsedObject = Object::fromBinary($binaryData, $offsetIndex);
+        $parsedObject = ASNObject::fromBinary($binaryData, $offsetIndex);
         $this->assertTrue($parsedObject instanceof UnknownObject);
         $this->assertEquals(substr($binaryData, 0, 3), $parsedObject->getIdentifier());
         $this->assertEquals('Unparsable Object (1 bytes)', $parsedObject->getContent());
@@ -228,7 +228,7 @@ class ObjectTest extends ASN1TestCase
     {
         $binaryData = 0x0;
         $offset = 10;
-        Object::fromBinary($binaryData, $offset);
+        ASNObject::fromBinary($binaryData, $offset);
     }
 
     /**
@@ -239,7 +239,7 @@ class ObjectTest extends ASN1TestCase
     public function testFromBinaryWithEmptyStringThrowsException()
     {
         $data = '';
-        Object::fromBinary($data);
+        ASNObject::fromBinary($data);
     }
 
     /**
@@ -250,7 +250,7 @@ class ObjectTest extends ASN1TestCase
     public function testFromBinaryWithSpacyStringThrowsException()
     {
         $data = '  ';
-        Object::fromBinary($data);
+        ASNObject::fromBinary($data);
     }
 
     /**
@@ -261,7 +261,7 @@ class ObjectTest extends ASN1TestCase
     public function testFromBinaryWithNumberStringThrowsException()
     {
         $data = '1';
-        Object::fromBinary($data);
+        ASNObject::fromBinary($data);
     }
 
     /**
@@ -272,7 +272,7 @@ class ObjectTest extends ASN1TestCase
     public function testFromBinaryWithGarbageStringThrowsException()
     {
         $data = 'certainly no asn.1 object';
-        Object::fromBinary($data);
+        ASNObject::fromBinary($data);
     }
 
     /**
@@ -283,7 +283,7 @@ class ObjectTest extends ASN1TestCase
     public function testFromBinaryUnknownObjectMissingLength()
     {
         $data = hex2bin('1f');
-        Object::fromBinary($data);
+        ASNObject::fromBinary($data);
     }
 
     /**
@@ -298,6 +298,6 @@ class ObjectTest extends ASN1TestCase
         $binaryData .= chr(0x1);  //only give one content-length-octet
         $binaryData .= chr(0x1);  //this is needed to reach the code to be tested
 
-        Object::fromBinary($binaryData);
+        ASNObject::fromBinary($binaryData);
     }
 }

--- a/tests/ASN1/Universal/IntegerTest.php
+++ b/tests/ASN1/Universal/IntegerTest.php
@@ -10,7 +10,7 @@
 
 namespace FG\Test\ASN1\Universal;
 
-use FG\ASN1\Object;
+use FG\ASN1\ASNObject;
 use FG\Test\ASN1TestCase;
 use FG\ASN1\Identifier;
 use FG\ASN1\Universal\Integer;
@@ -164,7 +164,7 @@ class IntegerTest extends ASN1TestCase
         $binary = $object->getBinary();
         $this->assertEquals($expectedType.$expectedLength.$expectedContent, $binary);
 
-        $obj = Object::fromBinary($binary);
+        $obj = ASNObject::fromBinary($binary);
         $this->assertEquals($obj, $object);
 
         // Test a negative number
@@ -178,7 +178,7 @@ class IntegerTest extends ASN1TestCase
         $binary = $object->getBinary();
         $this->assertEquals($expectedType.$expectedLength.$expectedContent, $binary);
 
-        $obj = Object::fromBinary($binary);
+        $obj = ASNObject::fromBinary($binary);
         $this->assertEquals($object, $obj);
     }
 
@@ -190,7 +190,7 @@ class IntegerTest extends ASN1TestCase
         $object = new Integer($i);
         $binary = $object->getBinary();
 
-        $obj = Object::fromBinary($binary);
+        $obj = ASNObject::fromBinary($binary);
         $this->assertEquals($obj->getContent(), $object->getContent());
     }
 

--- a/tests/DocumentationExamplesTest.php
+++ b/tests/DocumentationExamplesTest.php
@@ -11,7 +11,7 @@
 namespace FG\Test;
 
 use FG\ASN1\OID;
-use FG\ASN1\Object;
+use FG\ASN1\ASNObject;
 use FG\ASN1\Universal\Integer;
 use FG\ASN1\Universal\Boolean;
 use FG\ASN1\Universal\Enumerated;
@@ -52,7 +52,7 @@ class DocumentationExamplesTest extends ASN1TestCase
         $base64String = 'MBgCAwHiQAEB/woBARYLSGVsbG8gd29ybGQxODAYAgMB4kABAf8KAQEWC0hlbGxvIHdvcmxkBQAGBiqBegEQCQYJKoZIhvcNAQEBEwdGb28gYmFy';
         $binaryData = base64_decode($base64String);
 
-        $asnObject = Object::fromBinary($binaryData);
+        $asnObject = ASNObject::fromBinary($binaryData);
         $this->assertInstanceOf(Sequence::class, $asnObject);
     }
 }


### PR DESCRIPTION
This is perhaps contentious, but if you maintain a project that *has* to (sadly) ensure PHP 5.6 compatibility whilst at the same time encouraging and recommending usage of PHP 7.x then currently version 1.5 is counter-productive.

This pull request represents a candidate 1.6 release. It simply renames `Object` to `ASNObject` as has already been done in 2.x and I believe after a review and testing that this is the only remaining PHP 7.2 compatibility issue.

I know that no one will be jumping at the chance to encourage people to remain on PHP 5.6 but our software has a considerable number of customers on PHP 5.6 (nearly 40%) and thankfully this is dwindling but enforcing usage of PHP 7.x at this point isn't an option, so ideally we need to cater for the possibility of customers still being on PHP 5.6 whilst also boasting support for the latest and greatest PHP 7.2

I hope that makes sense!