### PR TITLE
v2.0.x: Wycheproof fixups

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "~6.3",
-        "satooshi/php-coveralls": "dev-master"
+        "satooshi/php-coveralls": "^1.0|^2.0"
     },
     "suggest": {
         "php-curl": "For loading OID information from the web if they have not bee defined statically"

--- a/lib/ASN1/ASNObject.php
+++ b/lib/ASN1/ASNObject.php
@@ -344,6 +344,12 @@ abstract class ASNObject implements Parsable
             throw new ParserException('A '.get_called_class()." should have a content length of at least {$minimumLength}. Extracted length was {$contentLength}", $offsetIndex);
         }
 
+        $lenDataRemaining = strlen($binaryData) - $offsetIndex;
+
+        if ($lenDataRemaining < $contentLength) {
+            throw new ParserException("Can not parse content length from data. Content length {$contentLength} exceeds remaining data length {$lenDataRemaining}", $offsetIndex);
+        }
+
         return $contentLength;
     }
 }

--- a/lib/ASN1/ASNObject.php
+++ b/lib/ASN1/ASNObject.php
@@ -347,7 +347,7 @@ abstract class ASNObject implements Parsable
         $lenDataRemaining = strlen($binaryData) - $offsetIndex;
 
         if ($lenDataRemaining < $contentLength) {
-            throw new ParserException("Can not parse content length from data. Content length {$contentLength} exceeds remaining data length {$lenDataRemaining}", $offsetIndex);
+            throw new ParserException("Content length {$contentLength} exceeds remaining data length {$lenDataRemaining}", $offsetIndex);
         }
 
         return $contentLength;

--- a/lib/ASN1/Construct.php
+++ b/lib/ASN1/Construct.php
@@ -13,6 +13,7 @@ namespace FG\ASN1;
 use ArrayAccess;
 use ArrayIterator;
 use Countable;
+use FG\ASN1\Exception\ParserException;
 use Iterator;
 
 abstract class Construct extends ASNObject implements Countable, ArrayAccess, Iterator, Parsable
@@ -158,6 +159,7 @@ abstract class Construct extends ASNObject implements Countable, ArrayAccess, It
         $parsedObject = new static();
         self::parseIdentifier($binaryData[$offsetIndex], $parsedObject->getType(), $offsetIndex++);
         $contentLength = self::parseContentLength($binaryData, $offsetIndex);
+        $startIndex = $offsetIndex;
 
         $children = [];
         $octetsToRead = $contentLength;
@@ -165,6 +167,10 @@ abstract class Construct extends ASNObject implements Countable, ArrayAccess, It
             $newChild = ASNObject::fromBinary($binaryData, $offsetIndex);
             $octetsToRead -= $newChild->getObjectLength();
             $children[] = $newChild;
+        }
+
+        if ($octetsToRead !== 0) {
+            throw new ParserException("Sequence length incorrect", $startIndex);
         }
 
         $parsedObject->addChildren($children);

--- a/lib/ASN1/Universal/BitString.php
+++ b/lib/ASN1/Universal/BitString.php
@@ -11,6 +11,7 @@
 namespace FG\ASN1\Universal;
 
 use Exception;
+use FG\ASN1\Exception\ParserException;
 use FG\ASN1\Parsable;
 use FG\ASN1\Identifier;
 
@@ -69,6 +70,14 @@ class BitString extends OctetString implements Parsable
 
         $nrOfUnusedBits = ord($binaryData[$offsetIndex]);
         $value = substr($binaryData, $offsetIndex + 1, $contentLength - 1);
+
+        if ($nrOfUnusedBits > 7 || // no less than 1 used, otherwise non-minimal
+            ($contentLength - 1) == 1 && $nrOfUnusedBits > 0 || // content length only 1, no
+            (ord($value[strlen($value)-1])&((1<<$nrOfUnusedBits)-1)) != 0 // unused bits set
+        ) {
+            throw new ParserException("Can not parse bit string with invalid padding", $offsetIndex);
+        }
+
         $offsetIndex += $contentLength;
 
         $parsedObject = new self(bin2hex($value), $nrOfUnusedBits);

--- a/lib/ASN1/Universal/Integer.php
+++ b/lib/ASN1/Universal/Integer.php
@@ -11,6 +11,7 @@
 namespace FG\ASN1\Universal;
 
 use Exception;
+use FG\ASN1\Exception\ParserException;
 use FG\ASN1\ASNObject;
 use FG\ASN1\Parsable;
 use FG\ASN1\Identifier;
@@ -107,7 +108,9 @@ class Integer extends ASNObject implements Parsable
         $parsedObject = new static(0);
         self::parseIdentifier($binaryData[$offsetIndex], $parsedObject->getType(), $offsetIndex++);
         $contentLength = self::parseContentLength($binaryData, $offsetIndex, 1);
-
+        if (strlen($binaryData) - $offsetIndex < $contentLength) {
+            throw new ParserException("Invalid length for content", $offsetIndex);
+        }
         $isNegative = (ord($binaryData[$offsetIndex]) & 0x80) != 0x00;
         $number = gmp_init(ord($binaryData[$offsetIndex++]) & 0x7F, 10);
 

--- a/lib/ASN1/Universal/Integer.php
+++ b/lib/ASN1/Universal/Integer.php
@@ -103,6 +103,14 @@ class Integer extends ASNObject implements Parsable
         return $r;
     }
 
+    protected static function checkBytes($binaryData, $offsetIndex)
+    {
+        if ((ord($binaryData[$offsetIndex]) == 0x00 && (ord($binaryData[$offsetIndex+1]) & 0x80) == 0) ||
+            (ord($binaryData[$offsetIndex]) == 0xff && (ord($binaryData[$offsetIndex+1]) & 0x80) == 0x80)) {
+            throw new ParserException("Integer not minimally encoded", $offsetIndex);
+        }
+    }
+
     public static function fromBinary(&$binaryData, &$offsetIndex = 0)
     {
         $parsedObject = new static(0);
@@ -111,9 +119,13 @@ class Integer extends ASNObject implements Parsable
         if (strlen($binaryData) - $offsetIndex < $contentLength) {
             throw new ParserException("Invalid length for content", $offsetIndex);
         }
+
+        if ($contentLength > 1) {
+            self::checkBytes($binaryData, $offsetIndex);
+        }
         $isNegative = (ord($binaryData[$offsetIndex]) & 0x80) != 0x00;
         $number = gmp_init(ord($binaryData[$offsetIndex++]) & 0x7F, 10);
-
+        
         for ($i = 0; $i < $contentLength - 1; $i++) {
             $number = gmp_or(gmp_mul($number, 0x100), ord($binaryData[$offsetIndex++]));
         }

--- a/lib/ASN1/Universal/Integer.php
+++ b/lib/ASN1/Universal/Integer.php
@@ -105,6 +105,8 @@ class Integer extends ASNObject implements Parsable
 
     private static function ensureMinimalEncoding($binaryData, $offsetIndex)
     {
+        // All the first nine bits cannot equal 0 or 1, which would
+        // be non-minimal encoding for positive and negative integers respectively
         if ((ord($binaryData[$offsetIndex]) == 0x00 && (ord($binaryData[$offsetIndex+1]) & 0x80) == 0) ||
             (ord($binaryData[$offsetIndex]) == 0xff && (ord($binaryData[$offsetIndex+1]) & 0x80) == 0x80)) {
             throw new ParserException("Integer not minimally encoded", $offsetIndex);

--- a/lib/ASN1/Universal/Integer.php
+++ b/lib/ASN1/Universal/Integer.php
@@ -116,9 +116,6 @@ class Integer extends ASNObject implements Parsable
         $parsedObject = new static(0);
         self::parseIdentifier($binaryData[$offsetIndex], $parsedObject->getType(), $offsetIndex++);
         $contentLength = self::parseContentLength($binaryData, $offsetIndex, 1);
-        if (strlen($binaryData) - $offsetIndex < $contentLength) {
-            throw new ParserException("Invalid length for content", $offsetIndex);
-        }
 
         if ($contentLength > 1) {
             self::checkBytes($binaryData, $offsetIndex);

--- a/lib/ASN1/Universal/Integer.php
+++ b/lib/ASN1/Universal/Integer.php
@@ -103,7 +103,7 @@ class Integer extends ASNObject implements Parsable
         return $r;
     }
 
-    protected static function checkBytes($binaryData, $offsetIndex)
+    private static function ensureMinimalEncoding($binaryData, $offsetIndex)
     {
         if ((ord($binaryData[$offsetIndex]) == 0x00 && (ord($binaryData[$offsetIndex+1]) & 0x80) == 0) ||
             (ord($binaryData[$offsetIndex]) == 0xff && (ord($binaryData[$offsetIndex+1]) & 0x80) == 0x80)) {
@@ -118,7 +118,7 @@ class Integer extends ASNObject implements Parsable
         $contentLength = self::parseContentLength($binaryData, $offsetIndex, 1);
 
         if ($contentLength > 1) {
-            self::checkBytes($binaryData, $offsetIndex);
+            self::ensureMinimalEncoding($binaryData, $offsetIndex);
         }
         $isNegative = (ord($binaryData[$offsetIndex]) & 0x80) != 0x00;
         $number = gmp_init(ord($binaryData[$offsetIndex++]) & 0x7F, 10);

--- a/lib/ASN1/Universal/Integer.php
+++ b/lib/ASN1/Universal/Integer.php
@@ -45,13 +45,7 @@ class Integer extends ASNObject implements Parsable
 
     protected function calculateContentLength()
     {
-        $nrOfOctets = 1; // we need at least one octet
-        $tmpValue = gmp_abs(gmp_init($this->value, 10));
-        while (gmp_cmp($tmpValue, 127) > 0) {
-            $tmpValue = $this->rightShift($tmpValue, 8);
-            $nrOfOctets++;
-        }
-        return $nrOfOctets;
+        return strlen($this->getEncodedValue());
     }
 
     /**
@@ -68,21 +62,44 @@ class Integer extends ASNObject implements Parsable
 
     protected function getEncodedValue()
     {
-        $numericValue = gmp_init($this->value, 10);
-        $contentLength = $this->getContentLength();
-
-        if (gmp_sign($numericValue) < 0) {
-            $numericValue = gmp_add($numericValue, (gmp_sub(gmp_pow(2, 8 * $contentLength), 1)));
-            $numericValue = gmp_add($numericValue, 1);
+        $value = gmp_init($this->value, 10);
+        $negative = gmp_cmp($value, 0) < 0;
+        if ($negative) {
+             $value = gmp_abs($value);
+             $limit = 0x80;
+        } else {
+             $limit = 0x7f;
         }
 
-        $result = '';
-        for ($shiftLength = ($contentLength - 1) * 8; $shiftLength >= 0; $shiftLength -= 8) {
-            $octet = gmp_strval(gmp_mod($this->rightShift($numericValue, $shiftLength), 256));
-            $result .= chr($octet);
+        $mod = 0xff+1;
+        $values = [];
+        while(gmp_cmp($value, $limit) > 0) {
+            $values[] = (int) gmp_strval(gmp_mod($value, $mod), 10);
+            $value = $this->rightShift($value, 8);
         }
 
-        return $result;
+        $values[] = (int) gmp_strval(gmp_mod($value, $mod), 10);
+        $numValues = count($values);
+
+        if ($negative) {
+            for ($i = 0; $i < $numValues; $i++) {
+                $values[$i] = 0xff - $values[$i];
+            }
+            for ($i = 0; $i < $numValues; $i++) {
+                $values[$i] += 1;
+                if ($values[$i] <= 0xff) {
+                    break;
+                }
+                assert($i != $numValues - 1);
+                $values[$i] = 0;
+            }
+            if ($values[$numValues - 1] == 0x7f) {
+                $values[] = 0xff;
+            }
+        }
+        $values = array_reverse($values);
+        $r = pack("C*", ...$values);
+        return $r;
     }
 
     public static function fromBinary(&$binaryData, &$offsetIndex = 0)

--- a/lib/ASN1/Universal/ObjectIdentifier.php
+++ b/lib/ASN1/Universal/ObjectIdentifier.php
@@ -88,6 +88,9 @@ class ObjectIdentifier extends ASNObject implements Parsable
     {
         self::parseIdentifier($binaryData[$offsetIndex], Identifier::OBJECT_IDENTIFIER, $offsetIndex++);
         $contentLength = self::parseContentLength($binaryData, $offsetIndex, 1);
+        if (strlen($binaryData) - $offsetIndex < $contentLength) {
+            throw new ParserException("Cannot read OID, content length incorrect", $offsetIndex);
+        }
 
         $firstOctet = ord($binaryData[$offsetIndex++]);
         $oidString = floor($firstOctet / 40).'.'.($firstOctet % 40);

--- a/lib/ASN1/Universal/ObjectIdentifier.php
+++ b/lib/ASN1/Universal/ObjectIdentifier.php
@@ -88,9 +88,6 @@ class ObjectIdentifier extends ASNObject implements Parsable
     {
         self::parseIdentifier($binaryData[$offsetIndex], Identifier::OBJECT_IDENTIFIER, $offsetIndex++);
         $contentLength = self::parseContentLength($binaryData, $offsetIndex, 1);
-        if (strlen($binaryData) - $offsetIndex < $contentLength) {
-            throw new ParserException("Cannot read OID, content length incorrect", $offsetIndex);
-        }
 
         $firstOctet = ord($binaryData[$offsetIndex++]);
         $oidString = floor($firstOctet / 40).'.'.($firstOctet % 40);

--- a/tests/ASN1/ObjectTest.php
+++ b/tests/ASN1/ObjectTest.php
@@ -300,4 +300,15 @@ class ObjectTest extends ASN1TestCase
 
         ASNObject::fromBinary($binaryData);
     }
+
+    /**
+     * @expectedException \FG\ASN1\Exception\ParserException
+     * @expectedExceptionMessage ASN.1 Parser Exception at offset 11: Can not parse content length from data: length > maximum integer
+     * @depends testFromBinary
+     */
+    public function testFromBinaryExceedsMaxInt()
+    {
+        $bin = hex2bin("308901000000000000004502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db");
+        ASNObject::fromBinary($bin);
+    }
 }

--- a/tests/ASN1/ObjectTest.php
+++ b/tests/ASN1/ObjectTest.php
@@ -244,12 +244,12 @@ class ObjectTest extends ASN1TestCase
 
     /**
      * @expectedException \FG\ASN1\Exception\ParserException
-     * @expectedExceptionMessage ASN.1 Parser Exception at offset 2: Can not parse binary from data: Offset index larger than input size
-     * @depends testFromBinary
+     * @expectedExceptionMessage ASN.1 Parser Exception at offset 3: Can not parse content length from data: Offset index larger than input size
+     * @ depends testFromBinary
      */
     public function testFromBinaryWithSpacyStringThrowsException()
     {
-        $data = '  ';
+        $data = "\x32\x01\x32";
         ASNObject::fromBinary($data);
     }
 
@@ -266,7 +266,7 @@ class ObjectTest extends ASN1TestCase
 
     /**
      * @expectedException \FG\ASN1\Exception\ParserException
-     * @expectedExceptionMessage ASN.1 Parser Exception at offset 25: Can not parse content length from data: Offset index larger than input size
+     * @expectedExceptionMessage ASN.1 Parser Exception at offset 2: Can not parse content length from data. Content length 101 exceeds remaining data length 23
      * @depends testFromBinary
      */
     public function testFromBinaryWithGarbageStringThrowsException()
@@ -310,5 +310,17 @@ class ObjectTest extends ASN1TestCase
     {
         $bin = hex2bin("308901000000000000004502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db");
         ASNObject::fromBinary($bin);
+    }
+
+    /**
+     * @expectedException \FG\ASN1\Exception\ParserException
+     * @expectedExceptionMessage ASN.1 Parser Exception at offset 2: Can not parse content length from data. Content length 1 exceeds remaining data length 0
+     * @depends testFromBinary
+     */
+    public function testFromBinaryWithInconsistentLength()
+    {
+        $binaryData  = chr(Identifier::NULL);
+        $binaryData .= chr(0x01);
+        ASNObject::fromBinary($binaryData);
     }
 }

--- a/tests/ASN1/ObjectTest.php
+++ b/tests/ASN1/ObjectTest.php
@@ -244,12 +244,12 @@ class ObjectTest extends ASN1TestCase
 
     /**
      * @expectedException \FG\ASN1\Exception\ParserException
-     * @expectedExceptionMessage ASN.1 Parser Exception at offset 3: Can not parse content length from data: Offset index larger than input size
-     * @ depends testFromBinary
+     * @expectedExceptionMessage ASN.1 Parser Exception at offset 2: Can not parse content length from data. Content length 50 exceeds remaining data length 1
+     * @depends testFromBinary
      */
     public function testFromBinaryWithSpacyStringThrowsException()
     {
-        $data = "\x32\x01\x32";
+        $data = "\x32\x32\x32";
         ASNObject::fromBinary($data);
     }
 

--- a/tests/ASN1/ObjectTest.php
+++ b/tests/ASN1/ObjectTest.php
@@ -244,7 +244,7 @@ class ObjectTest extends ASN1TestCase
 
     /**
      * @expectedException \FG\ASN1\Exception\ParserException
-     * @expectedExceptionMessage ASN.1 Parser Exception at offset 2: Can not parse content length from data. Content length 50 exceeds remaining data length 1
+     * @expectedExceptionMessage ASN.1 Parser Exception at offset 2: Content length 50 exceeds remaining data length 1
      * @depends testFromBinary
      */
     public function testFromBinaryWithSpacyStringThrowsException()
@@ -266,7 +266,7 @@ class ObjectTest extends ASN1TestCase
 
     /**
      * @expectedException \FG\ASN1\Exception\ParserException
-     * @expectedExceptionMessage ASN.1 Parser Exception at offset 2: Can not parse content length from data. Content length 101 exceeds remaining data length 23
+     * @expectedExceptionMessage ASN.1 Parser Exception at offset 2: Content length 101 exceeds remaining data length 23
      * @depends testFromBinary
      */
     public function testFromBinaryWithGarbageStringThrowsException()
@@ -314,7 +314,7 @@ class ObjectTest extends ASN1TestCase
 
     /**
      * @expectedException \FG\ASN1\Exception\ParserException
-     * @expectedExceptionMessage ASN.1 Parser Exception at offset 2: Can not parse content length from data. Content length 1 exceeds remaining data length 0
+     * @expectedExceptionMessage ASN.1 Parser Exception at offset 2: Content length 1 exceeds remaining data length 0
      * @depends testFromBinary
      */
     public function testFromBinaryWithInconsistentLength()

--- a/tests/ASN1/Universal/BooleanTest.php
+++ b/tests/ASN1/Universal/BooleanTest.php
@@ -106,6 +106,7 @@ class BooleanTest extends ASN1TestCase
         $binaryData  = chr(Identifier::BOOLEAN);
         $binaryData .= chr(0x02);
         $binaryData .= chr(0xFF);
+        $binaryData .= chr(0xFF);
         Boolean::fromBinary($binaryData);
     }
 
@@ -118,7 +119,6 @@ class BooleanTest extends ASN1TestCase
     {
         $binaryData  = chr(Identifier::BOOLEAN);
         $binaryData .= chr(0x00);
-        $binaryData .= chr(0xFF);
         Boolean::fromBinary($binaryData);
     }
 }

--- a/tests/ASN1/Universal/IntegerTest.php
+++ b/tests/ASN1/Universal/IntegerTest.php
@@ -70,9 +70,11 @@ class IntegerTest extends ASN1TestCase
         $this->assertEquals($expectedSize, $negativeObj->getObjectLength());
 
         $positiveObj = new Integer(128);
-        $negativeObj = new Integer(-128);
         $expectedSize = 2 + 2;
         $this->assertEquals($expectedSize, $positiveObj->getObjectLength());
+
+        $negativeObj = new Integer(-128);
+        $expectedSize = 2 + 1;
         $this->assertEquals($expectedSize, $negativeObj->getObjectLength());
 
         $positiveObj = new Integer(0x7FFF);
@@ -82,9 +84,11 @@ class IntegerTest extends ASN1TestCase
         $this->assertEquals($expectedSize, $negativeObj->getObjectLength());
 
         $positiveObj = new Integer(0x8000);
-        $negativeObj = new Integer(-0x8000);
         $expectedSize = 2 + 3;
         $this->assertEquals($expectedSize, $positiveObj->getObjectLength());
+
+        $negativeObj = new Integer(-0x8000);
+        $expectedSize = 1 + 3;
         $this->assertEquals($expectedSize, $negativeObj->getObjectLength());
 
         $positiveObj = new Integer(0x7FFFFF);
@@ -94,9 +98,11 @@ class IntegerTest extends ASN1TestCase
         $this->assertEquals($expectedSize, $negativeObj->getObjectLength());
 
         $positiveObj = new Integer(0x800000);
-        $negativeObj = new Integer(-0x800000);
         $expectedSize = 2 + 4;
         $this->assertEquals($expectedSize, $positiveObj->getObjectLength());
+
+        $negativeObj = new Integer(-0x800000);
+        $expectedSize = 1 + 4;
         $this->assertEquals($expectedSize, $negativeObj->getObjectLength());
 
         $positiveObj = new Integer(0x7FFFFFFF);
@@ -260,4 +266,35 @@ class IntegerTest extends ASN1TestCase
         $binaryData .= chr(0xA0);
         Integer::fromBinary($binaryData);
     }
+
+    public function getNearLimitsFixtures()
+    {
+        return [
+            [0,"020100"],
+            [127,"02017f"],
+            [128,"02020080"],
+            [256,"02020100"],
+            [-128,"020180"],
+            [-129,"0202ff7f"],
+        ];
+    }
+
+    /**
+     * @dataProvider getNearLimitsFixtures
+     * @param $integerValue
+     * @param $der
+     * @throws \FG\ASN1\Exception\ParserException
+     */
+    public function testIntegerNearLimits($integerValue, $der)
+    {
+        $integer = new Integer($integerValue);
+        $this->assertEquals($der, bin2hex($integer->getBinary()));
+
+        $bin = hex2bin($der);
+        $parsed = Integer::fromBinary($bin);
+        $this->assertEquals($parsed->getType(), $integer->getType());
+        $this->assertEquals($parsed->getContent(), $integer->getContent());
+        $this->assertEquals($parsed->getObjectLength(), $integer->getObjectLength());
+    }
+
 }

--- a/tests/ASN1/Universal/IntegerTest.php
+++ b/tests/ASN1/Universal/IntegerTest.php
@@ -259,6 +259,18 @@ class IntegerTest extends ASN1TestCase
      * @expectedExceptionMessage ASN.1 Parser Exception at offset 2: A FG\ASN1\Universal\Integer should have a content length of at least 1. Extracted length was 0
      * @depends testFromBinary
      */
+    public function testFromBinaryWithInvalidLength00()
+    {
+        $binaryData  = chr(Identifier::INTEGER);
+        $binaryData .= chr(0x00);
+        Integer::fromBinary($binaryData);
+    }
+
+    /**
+     * @expectedException \FG\ASN1\Exception\ParserException
+     * @expectedExceptionMessage ASN.1 Parser Exception at offset 2: A FG\ASN1\Universal\Integer should have a content length of at least 1. Extracted length was 0
+     * @depends testFromBinary
+     */
     public function testFromBinaryWithInvalidLength01()
     {
         $binaryData  = chr(Identifier::INTEGER);
@@ -299,6 +311,48 @@ class IntegerTest extends ASN1TestCase
 
     /**
      * @expectedException \FG\ASN1\Exception\ParserException
+     * @expectedExceptionMessage Integer not minimally encoded
+     * @depends testFromBinary
+     */
+    public function testFromBinaryWithUnnecessary00Byte()
+    {
+        $binaryData  = chr(Identifier::INTEGER);
+        $binaryData .= chr(0x02);
+        $binaryData .= chr(0x00);
+        $binaryData .= chr(0x01);
+        Integer::fromBinary($binaryData); // 02020001 should be encoded as 020101
+    }
+
+    /**
+     * @expectedException \FG\ASN1\Exception\ParserException
+     * @expectedExceptionMessage Integer not minimally encoded
+     * @depends testFromBinary
+     */
+    public function testFromBinaryWithUnnecessaryFFByte()
+    {
+        $binaryData  = chr(Identifier::INTEGER);
+        $binaryData .= chr(0x02);
+        $binaryData .= chr(0xFF);
+        $binaryData .= chr(0xFF);
+        Integer::fromBinary($binaryData);
+    }
+
+    /**
+     * @expectedException \FG\ASN1\Exception\ParserException
+     * @expectedExceptionMessage ASN.1 Parser Exception at offset 2: Integer not minimally encoded
+     * @depends testFromBinary
+     */
+    public function testRejectsNonMinimalEncodingExtraZero()
+    {
+        $binaryData  = chr(Identifier::INTEGER);
+        $binaryData .= chr(0x02);
+        $binaryData .= chr(0x00);
+        $binaryData .= chr(0x01);
+        Integer::fromBinary($binaryData);
+    }
+
+    /**
+     * @expectedException \FG\ASN1\Exception\ParserException
      * @expectedExceptionMessage Invalid length for content
      * @depends testFromBinary
      */
@@ -307,6 +361,20 @@ class IntegerTest extends ASN1TestCase
         $binaryData  = chr(Identifier::INTEGER);
         $binaryData .= chr(0x02);
         $binaryData .= chr(0xA0);
+        Integer::fromBinary($binaryData);
+    }
+
+    /**
+     * @expectedException \FG\ASN1\Exception\ParserException
+     * @expectedExceptionMessage ASN.1 Parser Exception at offset 2: Integer not minimally encoded
+     * @depends testFromBinary
+     */
+    public function testRejectsNonMinimalEncodingExtraFF()
+    {
+        $binaryData  = chr(Identifier::INTEGER);
+        $binaryData .= chr(0x02);
+        $binaryData .= chr(0xff);
+        $binaryData .= chr(0x80);
         Integer::fromBinary($binaryData);
     }
 }

--- a/tests/ASN1/Universal/IntegerTest.php
+++ b/tests/ASN1/Universal/IntegerTest.php
@@ -297,4 +297,16 @@ class IntegerTest extends ASN1TestCase
         $this->assertEquals($parsed->getObjectLength(), $integer->getObjectLength());
     }
 
+    /**
+     * @expectedException \FG\ASN1\Exception\ParserException
+     * @expectedExceptionMessage Invalid length for content
+     * @depends testFromBinary
+     */
+    public function testFromBinaryWithInvalidLengthTooLarge()
+    {
+        $binaryData  = chr(Identifier::INTEGER);
+        $binaryData .= chr(0x02);
+        $binaryData .= chr(0xA0);
+        Integer::fromBinary($binaryData);
+    }
 }

--- a/tests/ASN1/Universal/IntegerTest.php
+++ b/tests/ASN1/Universal/IntegerTest.php
@@ -88,7 +88,7 @@ class IntegerTest extends ASN1TestCase
         $this->assertEquals($expectedSize, $positiveObj->getObjectLength());
 
         $negativeObj = new Integer(-0x8000);
-        $expectedSize = 1 + 3;
+        $expectedSize = 2 + 2;
         $this->assertEquals($expectedSize, $negativeObj->getObjectLength());
 
         $positiveObj = new Integer(0x7FFFFF);
@@ -102,7 +102,7 @@ class IntegerTest extends ASN1TestCase
         $this->assertEquals($expectedSize, $positiveObj->getObjectLength());
 
         $negativeObj = new Integer(-0x800000);
-        $expectedSize = 1 + 4;
+        $expectedSize = 2 + 3;
         $this->assertEquals($expectedSize, $negativeObj->getObjectLength());
 
         $positiveObj = new Integer(0x7FFFFFFF);

--- a/tests/ASN1/Universal/IntegerTest.php
+++ b/tests/ASN1/Universal/IntegerTest.php
@@ -353,19 +353,6 @@ class IntegerTest extends ASN1TestCase
 
     /**
      * @expectedException \FG\ASN1\Exception\ParserException
-     * @expectedExceptionMessage Invalid length for content
-     * @depends testFromBinary
-     */
-    public function testFromBinaryWithInvalidLengthTooLarge()
-    {
-        $binaryData  = chr(Identifier::INTEGER);
-        $binaryData .= chr(0x02);
-        $binaryData .= chr(0xA0);
-        Integer::fromBinary($binaryData);
-    }
-
-    /**
-     * @expectedException \FG\ASN1\Exception\ParserException
      * @expectedExceptionMessage ASN.1 Parser Exception at offset 2: Integer not minimally encoded
      * @depends testFromBinary
      */

--- a/tests/ASN1/Universal/NullObjectTest.php
+++ b/tests/ASN1/Universal/NullObjectTest.php
@@ -88,6 +88,7 @@ class NullObjectTest extends ASN1TestCase
     {
         $binaryData  = chr(Identifier::NULL);
         $binaryData .= chr(0x01);
+        $binaryData .= chr(0x01);
         NullObject::fromBinary($binaryData);
     }
 }

--- a/tests/ASN1/Universal/SequenceTest.php
+++ b/tests/ASN1/Universal/SequenceTest.php
@@ -163,4 +163,32 @@ class SequenceTest extends ASN1TestCase
         $sequence = new Sequence(); // this should be legal
         $this->assertEmpty($sequence);
     }
+
+    /**
+     * @expectedException \FG\ASN1\Exception\ParserException
+     * @expectedExceptionMessage Sequence length incorrect
+     */
+    public function testInvalidLengthTooShort()
+    {
+        $str = chr(Identifier::SEQUENCE);
+        $str .= chr(11); // should be 12
+
+        // Integer(1), 3 bytes
+        $str .= chr(0x02);
+        $str .= chr(0x01);
+        $str .= chr(0x01);
+
+        // Integer(1), 9 bytes
+        $str .= chr(0x02);
+        $str .= chr(0x07);
+        $str .= chr(0x01);
+        $str .= chr(0x02);
+        $str .= chr(0x03);
+        $str .= chr(0x04);
+        $str .= chr(0x05);
+        $str .= chr(0x06);
+        $str .= chr(0x07);
+
+        Sequence::fromBinary($str);
+    }
 }

--- a/tests/ASN1/Universal/UTCTimeTest.php
+++ b/tests/ASN1/Universal/UTCTimeTest.php
@@ -109,7 +109,7 @@ class UTCTimeTest extends ASN1TestCase
     {
         $dateTime = new \DateTime('1987-01-15 13:15:00', $this->UTC);
         $binaryData  = chr(Identifier::UTC_TIME);
-        $binaryData .= chr(13);
+        $binaryData .= chr(11);
         $binaryData .= '8701151315Z';
         $parsedObject = UTCTime::fromBinary($binaryData);
         $this->assertEquals($dateTime, $parsedObject->getContent());


### PR DESCRIPTION
This PR fixes some bugs in the library which are tested for in googles wycheproof project. These were uncovered via testing of [phpecc](https://github.com/phpecc/phpecc) against the ECDH and ECDSA fixtures here https://github.com/google/wycheproof/tree/f89f4c53a8845fcefcdb9f14ee9191dbe167e3e3/testvectors 

Most of the fixes are sanity checks around canonical encoding: that encoded lengths are valid, that data is large as claimed, and also non-minimally encoded integers. It also found some edge cases in integer serialization code.

I've tested this patch set against the three largest dependents of this library by running their test suites, and it seems no issues were introduced by this PR.

One design point I'm not happy about, is we now 'calculate' the serialized length of an Integer by serializing it, and taking the strings length.. A future PR can fix this by calculating the size properly

Also, would be nice to run the relevant wycheproof tests here at some point. We can borrow the phpecc structures (DER EC public keys, and signatures) and start there, but it'd also be worth implementing other structures that the wycheproof repo has tests for. We'll need a list of tags to filter out ASN1 related tests

See #77 for 1.5.x backport, and #76 for master