### PR TITLE
Suggest curl extension in Composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     },
     "suggest": {
         "ext-gmp": "GMP is the preferred extension for big integer calculations",
-        "php-curl": "For loading OID information from the web if they have not bee defined statically"
+        "ext-curl": "For loading OID information from the web if they have not bee defined statically"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
I just did a `composer install` and got the message:

> fgrosse/phpasn1 suggests installing php-curl (For loading OID information from the web if they have not bee defined statically)

I do have curl installed on the environment I'm working on. I believe that the suggest section should suggest `ext-curl` and not `php-curl` (I couldn't find any Composer package named `php-curl`).