### PR TITLE
Pure PHP BigInteger support through phpseclib/bcmath_compat

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
     "keywords": [ "x690", "x.690", "x.509", "x509", "asn1", "asn.1", "ber", "der", "binary", "encoding", "decoding" ],
 
     "require": {
-        "php": ">=7.0.0"
+        "php": ">=7.0.0",
+        "phpseclib/bcmath_compat": "^1.0.5"
     },
     "require-dev": {
         "phpunit/phpunit": "~6.3",

--- a/lib/Utility/BigInteger.php
+++ b/lib/Utility/BigInteger.php
@@ -56,12 +56,8 @@ abstract class BigInteger
             if (extension_loaded('gmp')) {
                 $ret = new BigIntegerGmp();
             }
-            elseif (extension_loaded('bcmath')) {
-                $ret = new BigIntegerBcmath();
-            }
             else {
-                // TODO: potentially offer pure php implementation?
-                throw new \RuntimeException('Requires GMP or bcmath extension.');
+	            $ret = new BigIntegerBcmath();
             }
         }
 

--- a/tests/Utility/BigIntegerBcmathTest.php
+++ b/tests/Utility/BigIntegerBcmathTest.php
@@ -12,7 +12,7 @@ class BigIntegerBcmathTest extends BigIntegerTest
 {
     protected function _isSupported()
     {
-        return extension_loaded('bcmath');
+        return true;
     }
 
     protected function _getMode()


### PR DESCRIPTION
This PR implements a pure PHP fallback when neither the GMP nor the BCmath extensions are installed. It simply uses [phpseclib/bcmath_compat](https://github.com/phpseclib/bcmath_compat) to provide a pure-PHP bcmath implementation. Essentially, I'm addressing the TODO item in `FG\Utility\BigInteger`.

When either the GMP or BCmath extensions are loaded they are of course still being used which is admittedly _much_ faster, by more than an order of magnitude.

All tests pass with this PR. I have also tested this in a real world context (WebAuthn) successfully.

My motivation for this PR is that if it's included and a new version is released I can update the WebAuthn implementation's dependencies in the Joomla 4 CMS to no longer require GMP or BCmatch.

Thank you in advance for your time and thank you very much for the effort you've put into this library! It's very much appreciated :)