### PR TITLE
Update CHANGELOG for 2.2.0, and back-fill CHANGELOG for 2.1.1 2.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+#### v2.2.0 (2020-08)
+* support polyfills for bcmath and gmp, and add a composer.json
+  suggestion for the `phpseclib/bcmath_polyfill` for servers unable
+  to install PHP the gmp or bcmath extensions.
+
+#### v.2.1.1 & &v.2.0.2 (2018-12)
+* add stricter validation around some structures, highlighed
+  by wycheproof test suite
+
 #### v.2.1.0 (2018-03)
 * add support for `bcmath` extension (making `gmp` optional)<br>
   https://github.com/fgrosse/PHPASN1/pull/68


### PR DESCRIPTION
Seems with #80 we'll need to do a minor version bump, making the next tag v2.2.0