### PR TITLE
Small fixes for PHPUnit 8 compatibility

### DIFF
--- a/tests/ASN1/Universal/GeneralizedTimeTest.php
+++ b/tests/ASN1/Universal/GeneralizedTimeTest.php
@@ -20,7 +20,7 @@ class GeneralizedTimeTest extends ASN1TestCase
 {
     private $UTC;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->UTC = new DateTimeZone('UTC');
     }

--- a/tests/ASN1/Universal/UTCTimeTest.php
+++ b/tests/ASN1/Universal/UTCTimeTest.php
@@ -18,7 +18,7 @@ class UTCTimeTest extends ASN1TestCase
 {
     private $UTC;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->UTC = new \DateTimeZone('UTC');
     }

--- a/tests/Utility/BigIntegerTest.php
+++ b/tests/Utility/BigIntegerTest.php
@@ -25,7 +25,7 @@ abstract class BigIntegerTest extends TestCase
      */
     abstract protected function _getMode();
 
-    protected function setUp()
+    protected function setUp(): void
     {
         if (!$this->_isSupported()) {
             $this->markTestSkipped(sprintf('Mode %s is not supported.', $this->_getMode()));
@@ -285,7 +285,7 @@ abstract class BigIntegerTest extends TestCase
         $this->assertSame('18446744073709551616', (string)$a->absoluteValue());
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         BigInteger::setPrefer(null);
     }


### PR DESCRIPTION
Tests fail to run on PHPUnit 8 or higher because those require that the return type (void) be specified for the setUp() and tearDown() functions. This change is backwards-compatible with at least PHPUnit 7.

PHPUnit 9 causes additional problems due to some warnings in 8 being turned into errors in 9. If you want, I can make a PR for that as well, but I don't think those changes will be backwards-compatible with PHPUnit 7.