### PR TITLE
PHP 8 Compatibility - DateTime::getLastErrors can return false|array

### DIFF
--- a/lib/ASN1/AbstractTime.php
+++ b/lib/ASN1/AbstractTime.php
@@ -46,7 +46,7 @@ abstract class AbstractTime extends ASNObject
     protected function getLastDateTimeErrors()
     {
         $messages = '';
-        $lastErrors = DateTime::getLastErrors();
+        $lastErrors = DateTime::getLastErrors() ?: ['errors' => []];
         foreach ($lastErrors['errors'] as $errorMessage) {
             $messages .= "{$errorMessage}, ";
         }


### PR DESCRIPTION
replacement for #94

DateTime::getLastErrors() is documented as returning array|false https://www.php.net/manual/en/datetime.getlasterrors.php

As discussed here https://github.com/symfony/symfony/pull/47428#issuecomment-1231483492

@derickr quoted as saying
"This is a bug fix as the new 8.2 behaviour is how it has been documented for over a decade."